### PR TITLE
Fix debug build compilation

### DIFF
--- a/src/Makefile.d/versions.mk
+++ b/src/Makefile.d/versions.mk
@@ -159,7 +159,7 @@ ifdef DEBUGMODE
 ifdef GCC48
 opts+=-Og
 else
-opts+=O0
+opts+=-O0
 endif
 endif
 


### PR DESCRIPTION
Got this compilation error when trying to compile a debug build with `DEBUGMODE=1`:

```
cc: warning: O0: linker input file unused because linking not done
cc: error: O0: linker input file not found: No such file or directory
```

This was caused by a missing `-` on the `O0`, causing it to be treated as a file instead, and since this was combined with `-c`, it tried to treat the `O0` as a linker file and failed due to a missing file.