### PR TITLE
Fix loss of momentum when travelling up multiple steps in a tic

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -238,7 +238,7 @@ static UINT8 *demobuffer = NULL;
 static UINT8 *demo_p, *demotime_p;
 static UINT8 *demoend;
 static UINT8 demoflags;
-static UINT16 demoversion;
+UINT16 demoversion;
 boolean singledemo; // quit after playing a demo from cmdline
 boolean demo_start; // don't start playing demo right away
 static boolean demosynced = true; // console warning message
@@ -3824,7 +3824,7 @@ char *G_BuildMapTitle(INT32 mapnum)
 // DEMO RECORDING
 //
 
-#define DEMOVERSION 0x0009
+#define DEMOVERSION 0x000A
 #define DEMOHEADER  "\xF0" "SRB2Replay" "\x0F"
 
 #define DF_GHOST        0x01 // This demo contains ghost data too!
@@ -4998,6 +4998,7 @@ UINT8 G_CmpDemoTime(char *oldname, char *newname)
 	case DEMOVERSION: // latest always supported
 	// compatibility available?
 	case 0x0008:
+	case 0x0009:
 		break;
 	// too old, cannot support.
 	default:
@@ -5138,6 +5139,7 @@ void G_DoPlayDemo(char *defdemoname)
 	case DEMOVERSION: // latest always supported
 	// compatibility available?
 	case 0x0008:
+	case 0x0009:
 		break;
 	// too old, cannot support.
 	default:

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -41,6 +41,7 @@ extern boolean demoplayback, titledemo, demorecording, timingdemo;
 // Quit after playing a demo from cmdline.
 extern boolean singledemo;
 extern boolean demo_start;
+extern UINT16 demoversion;
 
 extern mobj_t *metalplayback;
 

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2011,12 +2011,21 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, boolean allowdropoff)
 						tmhitthing = tmfloorthing;
 					return false; // too big a step up
 				}
+				else if (thingtop > tmceilingz && P_IsObjectOnGround(thing))
+				{
+					thing->z = tmceilingz - thing->height;
+					thing->ceilingz = tmceilingz;
+				}
 			}
 			else if (tmfloorz - thing->z > maxstep)
 			{
 				if (tmfloorthing)
 					tmhitthing = tmfloorthing;
 				return false; // too big a step up
+			}
+			else if (thing->z < tmfloorz && P_IsObjectOnGround(thing))
+			{
+				thing->z = thing->floorz = tmfloorz;
 			}
 
 			if (!allowdropoff && !(thing->flags & MF_FLOAT) && thing->type != MT_SKIM && !tmfloorthing)

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2011,7 +2011,7 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, boolean allowdropoff)
 						tmhitthing = tmfloorthing;
 					return false; // too big a step up
 				}
-				else if (thingtop > tmceilingz && P_IsObjectOnGround(thing))
+				else if ((!demoplayback || demoversion >= 0x000A) && thingtop > tmceilingz && P_IsObjectOnGround(thing))
 				{
 					thing->z = tmceilingz - thing->height;
 					thing->ceilingz = tmceilingz;
@@ -2023,7 +2023,7 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, boolean allowdropoff)
 					tmhitthing = tmfloorthing;
 				return false; // too big a step up
 			}
-			else if (thing->z < tmfloorz && P_IsObjectOnGround(thing))
+			else if ((!demoplayback || demoversion >= 0x000A) && thing->z < tmfloorz && P_IsObjectOnGround(thing))
 			{
 				thing->z = thing->floorz = tmfloorz;
 			}


### PR DESCRIPTION
With a fast enough character and/or with steep enough stairs, all momentum can be lost if you travel up them too quickly. This was caused due to an adjustment error when calculating step collision, where step-ups failed to take the difference in height of the collision box into consideration, which caused it to check only the top and bottom steps and thus think it was traveling higher than it actually was and block the movement.

This patch fixes this by updating the Z-axis to the highest point of the stairway, which causes it to always calculate the step distance from the highest point. That way, we can be sure that it always calculates the step height from the correct Z-axis.

The bug can be triggered most easily on [Technology Station](https://mb.srb2.org/threads/july-august-2015-voting.23568/) using [Inazuma](https://mb.srb2.org/threads/inazuma-the-deer.25832/), just make sure you have enough momentum when traveling up stairs.