### PR TITLE
Fix segfault when painstate is S_NULL

### DIFF
--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -3135,6 +3135,9 @@ boolean P_DamageMobj(mobj_t *target, mobj_t *inflictor, mobj_t *source, INT32 da
 			break;
 		}
 
+	if (P_MobjWasRemoved(target))
+		return true;
+
 	target->reactiontime = 0; // we're awake now...
 
 	if (source && source != target)


### PR DESCRIPTION
If an object's SOC definition had it's painstate set to `S_NULL`, the game would segfault when that object took damage. This was caused by the (to me) very iconic lack of a `P_MobjWasRemoved` check after the state was set in `P_DamageMobj`.

This bug can be triggered on [Quickman 2](https://mb.srb2.org/threads/january-february-2015-voting.23188/) by simply being hit. Note that it does not trigger consistently unless the game is compiled with `DEBUGMODE=1`.