### PR TITLE
Fix console input

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -770,7 +770,7 @@ boolean CON_Responder(event_t *ev)
 		}
 	}
 
-	if (ev->type == ev_text || ev->type == ev_console)
+	if (ev->type == ev_text)
 	{
 		if (!consoletoggle && consoleready)
 			CON_InputAddChar(key);


### PR DESCRIPTION
A minor goof while backporting native keyboard layout in #6, where console input would be blocked due to misplaced condition on event types. This event is handled further down, but this check blocked it since it exited early and required the console to be opened, which isn't really possible from the console on a dedicated server.