### PR TITLE
Fix numerous compilation warnings

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -1545,9 +1545,9 @@ static void CL_LoadReceivedSavegame(void)
 {
 	UINT8 *savebuffer = NULL;
 	size_t length, decompressedlen;
-	XBOXSTATIC char tmpsave[256];
+	XBOXSTATIC char *tmpsave = Z_Malloc(512, PU_STATIC, NULL);
 
-	sprintf(tmpsave, "%s" PATHSEP TMPSAVENAME, srb2home);
+	snprintf(tmpsave, 512, "%s" PATHSEP TMPSAVENAME, srb2home);
 
 	length = FIL_ReadFile(tmpsave, &savebuffer);
 
@@ -1555,6 +1555,7 @@ static void CL_LoadReceivedSavegame(void)
 	if (!length)
 	{
 		I_Error("Can't read savegame sent");
+		Z_Free(tmpsave);
 		return;
 	}
 
@@ -1597,6 +1598,7 @@ static void CL_LoadReceivedSavegame(void)
 		save_p = NULL;
 		if (unlink(tmpsave) == -1)
 			CONS_Alert(CONS_ERROR, M_GetText("Can't delete %s\n"), tmpsave);
+		Z_Free(tmpsave);
 		return;
 	}
 
@@ -1605,6 +1607,7 @@ static void CL_LoadReceivedSavegame(void)
 	save_p = NULL;
 	if (unlink(tmpsave) == -1)
 		CONS_Alert(CONS_ERROR, M_GetText("Can't delete %s\n"), tmpsave);
+	Z_Free(tmpsave);
 	consistancy[gametic%BACKUPTICS] = Consistancy();
 	CON_ToggleOff();
 }
@@ -2018,9 +2021,9 @@ static void CL_ConnectToServer(boolean viams)
 	tic_t asksent;
 #endif
 #ifdef JOININGAME
-	XBOXSTATIC char tmpsave[256];
+	XBOXSTATIC char *tmpsave = Z_Malloc(512, PU_STATIC, NULL);
 
-	sprintf(tmpsave, "%s" PATHSEP TMPSAVENAME, srb2home);
+	snprintf(tmpsave, 512, "%s" PATHSEP TMPSAVENAME, srb2home);
 #endif
 
 	cl_mode = CL_SEARCHING;
@@ -2081,7 +2084,12 @@ static void CL_ConnectToServer(boolean viams)
 #else
 		if (!CL_ServerConnectionTicker(viams, (char*)NULL, &oldtic, (tic_t *)NULL))
 #endif
+		{
+#ifdef JOININGAME
+			Z_Free(tmpsave);
+#endif
 			return;
+		}
 
 		if (server)
 		{
@@ -2096,6 +2104,9 @@ static void CL_ConnectToServer(boolean viams)
 	DEBFILE(va("Synchronisation Finished\n"));
 
 	displayplayer = consoleplayer;
+#ifdef JOININGAME
+	Z_Free(tmpsave);
+#endif
 }
 
 #ifndef NONET

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -3234,16 +3234,16 @@ static void Got_RequestAddfilecmd(UINT8 **cp, INT32 playernum)
 
 	if (ncs != FS_FOUND || toomany)
 	{
-		char message[256];
+		char *message = Z_Malloc(512, PU_STATIC, NULL);
 
 		if (toomany)
-			sprintf(message, M_GetText("Too many files loaded to add %s\n"), filename);
+			snprintf(message, 512, M_GetText("Too many files loaded to add %s\n"), filename);
 		else if (ncs == FS_NOTFOUND)
-			sprintf(message, M_GetText("The server doesn't have %s\n"), filename);
+			snprintf(message, 512, M_GetText("The server doesn't have %s\n"), filename);
 		else if (ncs == FS_MD5SUMBAD)
-			sprintf(message, M_GetText("Checksum mismatch on %s\n"), filename);
+			snprintf(message, 512, M_GetText("Checksum mismatch on %s\n"), filename);
 		else
-			sprintf(message, M_GetText("Unknown error finding wad file (%s)\n"), filename);
+			snprintf(message, 512, M_GetText("Unknown error finding wad file (%s)\n"), filename);
 
 		CONS_Printf("%s",message);
 
@@ -3251,6 +3251,7 @@ static void Got_RequestAddfilecmd(UINT8 **cp, INT32 playernum)
 			if (adminplayers[j])
 				COM_BufAddText(va("sayto %d %s", adminplayers[j], message));
 
+		Z_Free(message);
 		return;
 	}
 
@@ -4023,7 +4024,7 @@ void Command_Retry_f(void)
 		CONS_Printf(M_GetText("You must be in a level to use this.\n"));
 	else if (netgame || multiplayer)
 		CONS_Printf(M_GetText("This only works in single player.\n"));
-	else if (!&players[consoleplayer] || players[consoleplayer].lives <= 1)
+	else if (players[consoleplayer].lives <= 1)
 		CONS_Printf(M_GetText("You can't retry without any lives remaining!\n"));
 	else if (G_IsSpecialStage(gamemap))
 		CONS_Printf(M_GetText("You can't retry special stages!\n"));

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1779,7 +1779,7 @@ static INT32 M_GetFirstLevelInList(void);
 static void Nextmap_OnChange(void)
 {
 	char *leveltitle;
-	char tabase[256];
+	char *tabase = Z_Malloc(512, PU_STATIC, NULL);
 	short i;
 	boolean active;
 
@@ -1804,7 +1804,7 @@ static void Nextmap_OnChange(void)
 		SP_NightsAttackMenu[naghost].status = IT_DISABLED;
 
 		// Check if file exists, if not, disable REPLAY option
-		sprintf(tabase,"%s"PATHSEP"replay"PATHSEP"%s"PATHSEP"%s",srb2home, timeattackfolder, G_BuildMapName(cv_nextmap.value));
+		snprintf(tabase, 512, "%s"PATHSEP"replay"PATHSEP"%s"PATHSEP"%s",srb2home, timeattackfolder, G_BuildMapName(cv_nextmap.value));
 		for (i = 0; i < 4; i++) {
 			SP_NightsReplayMenu[i].status = IT_DISABLED;
 			SP_NightsGuestReplayMenu[i].status = IT_DISABLED;
@@ -1848,7 +1848,7 @@ static void Nextmap_OnChange(void)
 		SP_TimeAttackMenu[taghost].status = IT_DISABLED;
 
 		// Check if file exists, if not, disable REPLAY option
-		sprintf(tabase,"%s"PATHSEP"replay"PATHSEP"%s"PATHSEP"%s-%s",srb2home, timeattackfolder, G_BuildMapName(cv_nextmap.value), cv_chooseskin.string);
+		snprintf(tabase, 512, "%s"PATHSEP"replay"PATHSEP"%s"PATHSEP"%s-%s",srb2home, timeattackfolder, G_BuildMapName(cv_nextmap.value), cv_chooseskin.string);
 		for (i = 0; i < 5; i++) {
 			SP_ReplayMenu[i].status = IT_DISABLED;
 			SP_GuestReplayMenu[i].status = IT_DISABLED;
@@ -1892,6 +1892,7 @@ static void Nextmap_OnChange(void)
 		if (mapheaderinfo[cv_nextmap.value-1] && mapheaderinfo[cv_nextmap.value-1]->forcecharacter[0] != '\0')
 			CV_Set(&cv_chooseskin, mapheaderinfo[cv_nextmap.value-1]->forcecharacter);
 	}
+	Z_Free(tabase);
 }
 
 static void Dummymares_OnChange(void)
@@ -2621,12 +2622,9 @@ void M_StartControlPanel(void)
 
 			SPauseMenu[spause_pandora].status = (M_SecretUnlocked(SECRET_PANDORA)) ? (IT_STRING | IT_CALL) : (IT_DISABLED);
 
-			if (&players[consoleplayer])
-			{
-				numlives = players[consoleplayer].lives;
-				if (players[consoleplayer].playerstate != PST_LIVE)
-					++numlives;
-			}
+			numlives = players[consoleplayer].lives;
+			if (players[consoleplayer].playerstate != PST_LIVE)
+				++numlives;
 
 			// The list of things that can disable retrying is (was?) a little too complex
 			// for me to want to use the short if statement syntax
@@ -2682,7 +2680,7 @@ void M_StartControlPanel(void)
 			if (G_GametypeHasTeams())
 				MPauseMenu[mpause_switchteam].status = IT_STRING | IT_SUBMENU;
 			else if (G_GametypeHasSpectators())
-				MPauseMenu[((&players[consoleplayer] && players[consoleplayer].spectator) ? mpause_entergame : mpause_spectate)].status = IT_STRING | IT_CALL;
+				MPauseMenu[(players[consoleplayer].spectator ? mpause_entergame : mpause_spectate)].status = IT_STRING | IT_CALL;
 			else // in this odd case, we still want something to be on the menu even if it's useless
 				MPauseMenu[mpause_spectate].status = IT_GRAYEDOUT;
 		}
@@ -4620,7 +4618,7 @@ static void M_RetryResponse(INT32 ch)
 	if (ch != 'y' && ch != KEY_ENTER)
 		return;
 
-	if (!&players[consoleplayer] || netgame || multiplayer) // Should never happen!
+	if (netgame || multiplayer) // Should never happen!
 		return;
 
 	M_ClearMenus(true);

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -760,7 +760,7 @@ static void M_PNGText(png_structp png_ptr, png_infop png_info_ptr, PNG_CONST png
 	else
 		snprintf(lvlttltext, 48, "Unknown");
 
-	if (gamestate == GS_LEVEL && &players[displayplayer] && players[displayplayer].mo)
+	if (gamestate == GS_LEVEL && players[displayplayer].mo)
 		snprintf(locationtxt, 40, "X:%d Y:%d Z:%d A:%d",
 			players[displayplayer].mo->x>>FRACBITS,
 			players[displayplayer].mo->y>>FRACBITS,

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -617,7 +617,7 @@ typedef struct
 {
 	UINT8 topdelta; // -1 is the last post in a column
 	UINT8 length;   // length data bytes follows
-} ATTRPACK post_t;
+} post_t;
 
 #if defined(_MSC_VER)
 #pragma pack()
@@ -700,7 +700,7 @@ typedef struct
 	INT16 topoffset;      // pixels below the origin
 	INT32 columnofs[8];     // only [width] used
 	// the [0] is &columnofs[width]
-} ATTRPACK patch_t;
+} patch_t;
 
 #ifdef _MSC_VER
 #pragma warning(disable :  4200)
@@ -716,7 +716,7 @@ typedef struct
 	INT16 height;
 	INT16 reserved1; // set to 0
 	UINT8 data[0];
-} ATTRPACK pic_t;
+} pic_t;
 
 #ifdef _MSC_VER
 #pragma warning(default : 4200)

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -611,8 +611,6 @@ static lumpinfo_t* ResGetLumpsZip (FILE* handle, UINT16* nlmp)
 		lump_p->name2 = Z_Calloc(zentry->namelen + 1, PU_STATIC, NULL);
 		strncpy(lump_p->name2, fullname, zentry->namelen);
 
-		free(fullname);
-
 		switch(zentry->compression)
 		{
 		case 0:
@@ -631,6 +629,8 @@ static lumpinfo_t* ResGetLumpsZip (FILE* handle, UINT16* nlmp)
 			lump_p->compression = CM_UNSUPPORTED;
 			break;
 		}
+
+		free(fullname);
 	}
 
 	free(zentries);
@@ -1707,7 +1707,7 @@ static int W_VerifyFile(const char *filename, lumpchecklist_t *checklist,
 				continue;
 
 			for (j = 0; j < NUMSPRITES; j++)
-				if (sprnames[j] && !strncmp(lumpinfo.name, sprnames[j], 4)) // Sprites
+				if (!strncmp(lumpinfo.name, sprnames[j], 4)) // Sprites
 					continue;
 
 			goodfile = false;


### PR DESCRIPTION
The current master has a bunch of compilation warnings which this patch fixes (except for one in blua, since i'm not familiar enough with blua to be able to fix it without ensuring it won't break anything). It also replaces some stack allocations with dynamic allocations to reduce risks of stack overflows.