### PR TITLE
Joystick Hotplugging 

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -48,13 +48,6 @@
 #include "m_anigif.h"
 #include "md5.h"
 
-#if defined(HAVE_SDL)
-#include "SDL.h"
-#if SDL_VERSION_ATLEAST(2,0,0)
-#include "sdl/sdlmain.h" // JOYSTICK_HOTPLUG
-#endif
-#endif
-
 #ifdef NETGAME_DEVMODE
 #define CV_RESTRICT CV_NETVAR
 #else
@@ -254,19 +247,10 @@ consvar_t cv_usemouse = {"use_mouse", "On", CV_SAVE|CV_CALL,usemouse_cons_t, I_S
 consvar_t cv_usemouse2 = {"use_mouse2", "Off", CV_SAVE|CV_CALL,usemouse_cons_t, I_StartupMouse2, 0, NULL, NULL, 0, 0, NULL};
 
 #if defined (DC) || defined (_XBOX) || defined (WMINPUT) || defined (_WII) || defined(HAVE_SDL) || defined(_WINDOWS) //joystick 1 and 2
-// JOYSTICK_HOTPLUG is set by sdlmain.h (SDL2)
-// because SDL joystick indexes are unstable, and hotplugging can change a device's index.
-// So let's not save any index changes to the config
-consvar_t cv_usejoystick = {"use_joystick", "1", CV_CALL
-#ifndef JOYSTICK_HOTPLUG
-	|CV_SAVE
-#endif
-	, usejoystick_cons_t, I_InitJoystick, 0, NULL, NULL, 0, 0, NULL};
-consvar_t cv_usejoystick2 = {"use_joystick2", "2", CV_CALL
-#ifndef JOYSTICK_HOTPLUG
-	|CV_SAVE
-#endif
-	, usejoystick_cons_t, I_InitJoystick2, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_usejoystick = {"use_joystick", "1", CV_SAVE|CV_CALL, usejoystick_cons_t,
+	I_InitJoystick, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_usejoystick2 = {"use_joystick2", "2", CV_SAVE|CV_CALL, usejoystick_cons_t,
+	I_InitJoystick2, 0, NULL, NULL, 0, 0, NULL};
 #elif defined (PSP) || defined (GP2X) || defined (_NDS) //only one joystick
 consvar_t cv_usejoystick = {"use_joystick", "1", CV_SAVE|CV_CALL, usejoystick_cons_t,
 	I_InitJoystick, 0, NULL, NULL, 0, 0, NULL};

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -48,6 +48,13 @@
 #include "m_anigif.h"
 #include "md5.h"
 
+#if defined(HAVE_SDL)
+#include "SDL.h"
+#if SDL_VERSION_ATLEAST(2,0,0)
+#include "sdl/sdlmain.h" // JOYSTICK_HOTPLUG
+#endif
+#endif
+
 #ifdef NETGAME_DEVMODE
 #define CV_RESTRICT CV_NETVAR
 #else
@@ -247,10 +254,19 @@ consvar_t cv_usemouse = {"use_mouse", "On", CV_SAVE|CV_CALL,usemouse_cons_t, I_S
 consvar_t cv_usemouse2 = {"use_mouse2", "Off", CV_SAVE|CV_CALL,usemouse_cons_t, I_StartupMouse2, 0, NULL, NULL, 0, 0, NULL};
 
 #if defined (DC) || defined (_XBOX) || defined (WMINPUT) || defined (_WII) || defined(HAVE_SDL) || defined(_WINDOWS) //joystick 1 and 2
-consvar_t cv_usejoystick = {"use_joystick", "1", CV_SAVE|CV_CALL, usejoystick_cons_t,
-	I_InitJoystick, 0, NULL, NULL, 0, 0, NULL};
-consvar_t cv_usejoystick2 = {"use_joystick2", "2", CV_SAVE|CV_CALL, usejoystick_cons_t,
-	I_InitJoystick2, 0, NULL, NULL, 0, 0, NULL};
+// JOYSTICK_HOTPLUG is set by sdlmain.h (SDL2)
+// because SDL joystick indexes are unstable, and hotplugging can change a device's index.
+// So let's not save any index changes to the config
+consvar_t cv_usejoystick = {"use_joystick", "1", CV_CALL
+#ifndef JOYSTICK_HOTPLUG
+	|CV_SAVE
+#endif
+	, usejoystick_cons_t, I_InitJoystick, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_usejoystick2 = {"use_joystick2", "2", CV_CALL
+#ifndef JOYSTICK_HOTPLUG
+	|CV_SAVE
+#endif
+	, usejoystick_cons_t, I_InitJoystick2, 0, NULL, NULL, 0, 0, NULL};
 #elif defined (PSP) || defined (GP2X) || defined (_NDS) //only one joystick
 consvar_t cv_usejoystick = {"use_joystick", "1", CV_SAVE|CV_CALL, usejoystick_cons_t,
 	I_InitJoystick, 0, NULL, NULL, 0, 0, NULL};

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -65,6 +65,13 @@
 // And just some randomness for the exits.
 #include "m_random.h"
 
+#if defined(HAVE_SDL)
+#include "SDL.h"
+#if SDL_VERSION_ATLEAST(2,0,0)
+#include "sdl/sdlmain.h" // JOYSTICK_HOTPLUG
+#endif
+#endif
+
 #ifdef PC_DOS
 #include <stdio.h> // for snprintf
 int	snprintf(char *str, size_t n, const char *fmt, ...);
@@ -7479,12 +7486,34 @@ void M_SetupJoystickMenu(INT32 choice)
 
 	strcpy(joystickInfo[i], "None");
 
+#ifdef JOYSTICK_HOTPLUG
+	if (0 == cv_usejoystick.value)
+		CV_SetValue(&cv_usejoystick, 0);
+	if (0 == cv_usejoystick2.value)
+		CV_SetValue(&cv_usejoystick2, 0);
+#endif
+
 	for (i = 1; i < 8; i++)
 	{
 		if (i <= n && (I_GetJoyName(i)) != NULL)
 			strncpy(joystickInfo[i], I_GetJoyName(i), 28);
 		else
 			strcpy(joystickInfo[i], joyNA);
+
+#ifdef JOYSTICK_HOTPLUG
+		// We use cv_usejoystick.string as the USER-SET var
+		// and cv_usejoystick.value as the INTERNAL var
+		//
+		// In practice, if cv_usejoystick.string == 0, this overrides
+		// cv_usejoystick.value and always disables
+		//
+		// Update cv_usejoystick.string here so that the user can
+		// properly change this value.
+		if (i == cv_usejoystick.value)
+			CV_SetValue(&cv_usejoystick, i);
+		if (i == cv_usejoystick2.value)
+			CV_SetValue(&cv_usejoystick2, i);
+#endif
 	}
 
 	M_SetupNextMenu(&OP_JoystickSetDef);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -7486,7 +7486,9 @@ void M_SetupJoystickMenu(INT32 choice)
 
 	strcpy(joystickInfo[i], "None");
 
-#ifdef JOYSTICK_HOTPLUG
+	// Hotplugging breaks if this block is run
+	// Because the cvar is set to 0, which disables controllers for that player
+#if 0 // #ifdef JOYSTICK_HOTPLUG
 	if (0 == cv_usejoystick.value)
 		CV_SetValue(&cv_usejoystick, 0);
 	if (0 == cv_usejoystick2.value)
@@ -7535,10 +7537,60 @@ static void M_Setup2PJoystickMenu(INT32 choice)
 
 static void M_AssignJoystick(INT32 choice)
 {
+#ifdef JOYSTICK_HOTPLUG
+	INT32 oldchoice;
+
+	if (choice > I_NumJoys())
+		return;
+
+	if (setupcontrols_secondaryplayer)
+	{
+		oldchoice = cv_usejoystick2.value;
+		CV_SetValue(&cv_usejoystick2, choice);
+
+		// Just in case last-minute changes were made to cv_usejoystick.value,
+		// update the string too
+		CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
+
+		if (oldchoice != choice)
+		{
+			if (choice && oldchoice > I_NumJoys()) // if we did not select "None", we likely selected a used device
+				CV_SetValue(&cv_usejoystick2, oldchoice);
+
+			if (oldchoice == cv_usejoystick2.value)
+				M_StartMessage("This joystick is used by another\n"
+				               "player. Reset the joystick\n"
+							   "for that player first.\n\n"
+							   "(Press a key)\n", NULL, MM_NOTHING);
+		}
+	}
+	else
+	{
+		oldchoice = cv_usejoystick.value;
+		CV_SetValue(&cv_usejoystick, choice);
+
+		// Just in case last-minute changes were made to cv_usejoystick.value,
+		// update the string too
+		CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
+
+		if (oldchoice != choice)
+		{
+			if (choice && oldchoice > I_NumJoys()) // if we did not select "None", we likely selected a used device
+				CV_SetValue(&cv_usejoystick, oldchoice);
+
+			if (oldchoice == cv_usejoystick.value)
+				M_StartMessage("This joystick is used by another\n"
+				               "player. Reset the joystick\n"
+							   "for that player first.\n\n"
+							   "(Press a key)\n", NULL, MM_NOTHING);
+		}
+	}
+#else
 	if (setupcontrols_secondaryplayer)
 		CV_SetValue(&cv_usejoystick2, choice);
 	else
 		CV_SetValue(&cv_usejoystick, choice);
+#endif
 }
 
 // =============

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -7470,7 +7470,7 @@ static void M_DrawJoystick(void)
 	}
 }
 
-static void M_SetupJoystickMenu(INT32 choice)
+void M_SetupJoystickMenu(INT32 choice)
 {
 	INT32 i = 0;
 	const char *joyNA = "Unavailable";

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -7501,15 +7501,6 @@ void M_SetupJoystickMenu(INT32 choice)
 
 	strcpy(joystickInfo[i], "None");
 
-	// Hotplugging breaks if this block is run
-	// Because the cvar is set to 0, which disables controllers for that player
-#if 0 // #ifdef JOYSTICK_HOTPLUG
-	if (0 == cv_usejoystick.value)
-		CV_SetValue(&cv_usejoystick, 0);
-	if (0 == cv_usejoystick2.value)
-		CV_SetValue(&cv_usejoystick2, 0);
-#endif
-
 	for (i = 1; i < 8; i++)
 	{
 		if (i <= n && (I_GetJoyName(i)) != NULL)
@@ -7554,52 +7545,66 @@ static void M_AssignJoystick(INT32 choice)
 {
 #ifdef JOYSTICK_HOTPLUG
 	INT32 oldchoice;
-
-	if (choice > I_NumJoys())
-		return;
+	INT32 numjoys = I_NumJoys();
 
 	if (setupcontrols_secondaryplayer)
 	{
-		oldchoice = atoi(cv_usejoystick2.string) > I_NumJoys() ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value;
+		oldchoice = atoi(cv_usejoystick2.string) > numjoys ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value;
 		CV_SetValue(&cv_usejoystick2, choice);
 
 		// Just in case last-minute changes were made to cv_usejoystick.value,
 		// update the string too
-		CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
-
-		if (oldchoice != choice)
+		// But don't do this if we're intentionally setting higher than numjoys
+		if (choice <= numjoys)
 		{
-			if (choice && oldchoice > I_NumJoys()) // if we did not select "None", we likely selected a used device
-				CV_SetValue(&cv_usejoystick2, oldchoice);
+			CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
 
-			if (oldchoice ==
-				(atoi(cv_usejoystick2.string) > I_NumJoys() ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value))
-				M_StartMessage("This joystick is used by another\n"
-				               "player. Reset the joystick\n"
-							   "for that player first.\n\n"
-							   "(Press a key)\n", NULL, MM_NOTHING);
+			// reset this so the comparison is valid
+			if (oldchoice > numjoys)
+				oldchoice = cv_usejoystick2.value;
+
+			if (oldchoice != choice)
+			{
+				if (choice && oldchoice > numjoys) // if we did not select "None", we likely selected a used device
+					CV_SetValue(&cv_usejoystick2, oldchoice);
+
+				if (oldchoice ==
+					(atoi(cv_usejoystick2.string) > numjoys ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value))
+					M_StartMessage("This joystick is used by another\n"
+					               "player. Reset the joystick\n"
+					               "for that player first.\n\n"
+					               "(Press a key)\n", NULL, MM_NOTHING);
+			}
 		}
 	}
 	else
 	{
-		oldchoice = atoi(cv_usejoystick.string) > I_NumJoys() ? atoi(cv_usejoystick.string) : cv_usejoystick.value;
+		oldchoice = atoi(cv_usejoystick.string) > numjoys ? atoi(cv_usejoystick.string) : cv_usejoystick.value;
 		CV_SetValue(&cv_usejoystick, choice);
 
 		// Just in case last-minute changes were made to cv_usejoystick.value,
 		// update the string too
-		CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
-
-		if (oldchoice != choice)
+		// But don't do this if we're intentionally setting higher than numjoys
+		if (choice <= numjoys)
 		{
-			if (choice && oldchoice > I_NumJoys()) // if we did not select "None", we likely selected a used device
-				CV_SetValue(&cv_usejoystick, oldchoice);
+			CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
 
-			if (oldchoice ==
-				(atoi(cv_usejoystick.string) > I_NumJoys() ? atoi(cv_usejoystick.string) : cv_usejoystick.value))
-				M_StartMessage("This joystick is used by another\n"
-				               "player. Reset the joystick\n"
-							   "for that player first.\n\n"
-							   "(Press a key)\n", NULL, MM_NOTHING);
+			// reset this so the comparison is valid
+			if (oldchoice > numjoys)
+				oldchoice = cv_usejoystick.value;
+
+			if (oldchoice != choice)
+			{
+				if (choice && oldchoice > numjoys) // if we did not select "None", we likely selected a used device
+					CV_SetValue(&cv_usejoystick, oldchoice);
+
+				if (oldchoice ==
+					(atoi(cv_usejoystick.string) > numjoys ? atoi(cv_usejoystick.string) : cv_usejoystick.value))
+					M_StartMessage("This joystick is used by another\n"
+					               "player. Reset the joystick\n"
+					               "for that player first.\n\n"
+					               "(Press a key)\n", NULL, MM_NOTHING);
+			}
 		}
 	}
 #else

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -7460,7 +7460,7 @@ static void M_ScreenshotOptions(INT32 choice)
 
 static void M_DrawJoystick(void)
 {
-	INT32 i;
+	INT32 i, compareval2, compareval;
 
 	M_DrawGenericMenu();
 
@@ -7469,8 +7469,23 @@ static void M_DrawJoystick(void)
 		M_DrawTextBox(OP_JoystickSetDef.x-8, OP_JoystickSetDef.y+LINEHEIGHT*i-12, 28, 1);
 		//M_DrawSaveLoadBorder(OP_JoystickSetDef.x, OP_JoystickSetDef.y+LINEHEIGHT*i);
 
-		if ((setupcontrols_secondaryplayer && (i == cv_usejoystick2.value))
-			|| (!setupcontrols_secondaryplayer && (i == cv_usejoystick.value)))
+#ifdef JOYSTICK_HOTPLUG
+		if (atoi(cv_usejoystick2.string) > I_NumJoys())
+			compareval2 = atoi(cv_usejoystick2.string);
+		else
+			compareval2 = cv_usejoystick2.value;
+
+		if (atoi(cv_usejoystick.string) > I_NumJoys())
+			compareval = atoi(cv_usejoystick.string);
+		else
+			compareval = cv_usejoystick.value;
+#else
+		compareval2 = cv_usejoystick2.value;
+		compareval = cv_usejoystick.value
+#endif
+
+		if ((setupcontrols_secondaryplayer && (i == compareval2))
+			|| (!setupcontrols_secondaryplayer && (i == compareval)))
 			V_DrawString(OP_JoystickSetDef.x, OP_JoystickSetDef.y+LINEHEIGHT*i-4,V_GREENMAP,joystickInfo[i]);
 		else
 			V_DrawString(OP_JoystickSetDef.x, OP_JoystickSetDef.y+LINEHEIGHT*i-4,0,joystickInfo[i]);
@@ -7545,7 +7560,7 @@ static void M_AssignJoystick(INT32 choice)
 
 	if (setupcontrols_secondaryplayer)
 	{
-		oldchoice = cv_usejoystick2.value;
+		oldchoice = atoi(cv_usejoystick2.string) > I_NumJoys() ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value;
 		CV_SetValue(&cv_usejoystick2, choice);
 
 		// Just in case last-minute changes were made to cv_usejoystick.value,
@@ -7557,7 +7572,8 @@ static void M_AssignJoystick(INT32 choice)
 			if (choice && oldchoice > I_NumJoys()) // if we did not select "None", we likely selected a used device
 				CV_SetValue(&cv_usejoystick2, oldchoice);
 
-			if (oldchoice == cv_usejoystick2.value)
+			if (oldchoice ==
+				(atoi(cv_usejoystick2.string) > I_NumJoys() ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value))
 				M_StartMessage("This joystick is used by another\n"
 				               "player. Reset the joystick\n"
 							   "for that player first.\n\n"
@@ -7566,7 +7582,7 @@ static void M_AssignJoystick(INT32 choice)
 	}
 	else
 	{
-		oldchoice = cv_usejoystick.value;
+		oldchoice = atoi(cv_usejoystick.string) > I_NumJoys() ? atoi(cv_usejoystick.string) : cv_usejoystick.value;
 		CV_SetValue(&cv_usejoystick, choice);
 
 		// Just in case last-minute changes were made to cv_usejoystick.value,
@@ -7578,7 +7594,8 @@ static void M_AssignJoystick(INT32 choice)
 			if (choice && oldchoice > I_NumJoys()) // if we did not select "None", we likely selected a used device
 				CV_SetValue(&cv_usejoystick, oldchoice);
 
-			if (oldchoice == cv_usejoystick.value)
+			if (oldchoice ==
+				(atoi(cv_usejoystick.string) > I_NumJoys() ? atoi(cv_usejoystick.string) : cv_usejoystick.value))
 				M_StartMessage("This joystick is used by another\n"
 				               "player. Reset the joystick\n"
 							   "for that player first.\n\n"

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -7544,12 +7544,12 @@ static void M_Setup2PJoystickMenu(INT32 choice)
 static void M_AssignJoystick(INT32 choice)
 {
 #ifdef JOYSTICK_HOTPLUG
-	INT32 oldchoice;
+	INT32 oldchoice, oldstringchoice;
 	INT32 numjoys = I_NumJoys();
 
 	if (setupcontrols_secondaryplayer)
 	{
-		oldchoice = atoi(cv_usejoystick2.string) > numjoys ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value;
+		oldchoice = oldstringchoice = atoi(cv_usejoystick2.string) > numjoys ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value;
 		CV_SetValue(&cv_usejoystick2, choice);
 
 		// Just in case last-minute changes were made to cv_usejoystick.value,
@@ -7565,10 +7565,10 @@ static void M_AssignJoystick(INT32 choice)
 
 			if (oldchoice != choice)
 			{
-				if (choice && oldchoice > numjoys) // if we did not select "None", we likely selected a used device
-					CV_SetValue(&cv_usejoystick2, oldchoice);
+				if (choice && oldstringchoice > numjoys) // if we did not select "None", we likely selected a used device
+					CV_SetValue(&cv_usejoystick2, (oldstringchoice > numjoys ? oldstringchoice : oldchoice));
 
-				if (oldchoice ==
+				if (oldstringchoice ==
 					(atoi(cv_usejoystick2.string) > numjoys ? atoi(cv_usejoystick2.string) : cv_usejoystick2.value))
 					M_StartMessage("This joystick is used by another\n"
 					               "player. Reset the joystick\n"
@@ -7579,7 +7579,7 @@ static void M_AssignJoystick(INT32 choice)
 	}
 	else
 	{
-		oldchoice = atoi(cv_usejoystick.string) > numjoys ? atoi(cv_usejoystick.string) : cv_usejoystick.value;
+		oldchoice = oldstringchoice = atoi(cv_usejoystick.string) > numjoys ? atoi(cv_usejoystick.string) : cv_usejoystick.value;
 		CV_SetValue(&cv_usejoystick, choice);
 
 		// Just in case last-minute changes were made to cv_usejoystick.value,
@@ -7595,10 +7595,10 @@ static void M_AssignJoystick(INT32 choice)
 
 			if (oldchoice != choice)
 			{
-				if (choice && oldchoice > numjoys) // if we did not select "None", we likely selected a used device
-					CV_SetValue(&cv_usejoystick, oldchoice);
+				if (choice && oldstringchoice > numjoys) // if we did not select "None", we likely selected a used device
+					CV_SetValue(&cv_usejoystick, (oldstringchoice > numjoys ? oldstringchoice : oldchoice));
 
-				if (oldchoice ==
+				if (oldstringchoice ==
 					(atoi(cv_usejoystick.string) > numjoys ? atoi(cv_usejoystick.string) : cv_usejoystick.value))
 					M_StartMessage("This joystick is used by another\n"
 					               "player. Reset the joystick\n"

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -72,7 +72,6 @@ void M_QuitResponse(INT32 ch);
 // Determines whether to show a level in the list
 boolean M_CanShowLevelInList(INT32 mapnum, INT32 gt);
 
-
 // flags for items in the menu
 // menu handle (what we do when key is pressed
 #define IT_TYPE             14     // (2+4+8)
@@ -175,6 +174,10 @@ extern menu_t *currentMenu;
 
 extern menu_t MainDef;
 extern menu_t SP_LoadDef;
+
+// Call upon joystick hotplug
+void M_SetupJoystickMenu(INT32 choice);
+extern menu_t OP_JoystickSetDef;
 
 // Stuff for customizing the player select screen
 typedef struct

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -830,6 +830,23 @@ void I_JoyScale2(void)
 	JoyInfo2.scale = Joystick2.bGamepadStyle?1:cv_joyscale2.value;
 }
 
+// Cheat to get the device index for a joystick handle
+INT32 I_GetJoystickDeviceIndex(SDL_Joystick *dev)
+{
+	INT32 i, count = SDL_NumJoysticks();
+
+	for (i = 0; dev && i < count; i++)
+	{
+		SDL_Joystick *test = SDL_JoystickOpen(i);
+		if (test && test == dev)
+			return i;
+		else if (JoyInfo.dev != test && JoyInfo2.dev != test)
+			SDL_JoystickClose(test);
+	}
+
+	return -1;
+}
+
 /**	\brief Joystick 1 buttons states
 */
 static UINT64 lastjoybuttons = 0;
@@ -1395,9 +1412,8 @@ void I_InitJoystick(void)
 	if (cv_usejoystick.value && joy_open(cv_usejoystick.value) != -1)
 	{
 		// SDL's device indexes are unstable, so cv_usejoystick may not match
-		// the actual device index. So let's cheat a bit and use the instance ID.
-		// oldjoy's exact value doesn't matter, because we use it like a boolean
-		JoyInfo.oldjoy = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
+		// the actual device index. So let's cheat a bit and find the device's current index.
+		JoyInfo.oldjoy = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
 		joystick_started = 1;
 	}
 	else
@@ -1428,9 +1444,8 @@ void I_InitJoystick2(void)
 	if (cv_usejoystick2.value && joy_open2(cv_usejoystick2.value) != -1)
 	{
 		// SDL's device indexes are unstable, so cv_usejoystick2 may not match
-		// the actual device index. So let's cheat a bit and use the instance ID.
-		// oldjoy's exact value doesn't matter, because we use it like a boolean
-		JoyInfo2.oldjoy = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
+		// the actual device index. So let's cheat a bit and find the device's current index.
+		JoyInfo2.oldjoy = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
 		joystick2_started = 1;
 	}
 	else

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1394,6 +1394,8 @@ static int joy_open2(int joyindex)
 //
 void I_InitJoystick(void)
 {
+	SDL_Joystick *newjoy = NULL;
+
 	//I_ShutdownJoystick();
 	if (M_CheckParm("-nojoy"))
 		return;
@@ -1409,20 +1411,17 @@ void I_InitJoystick(void)
 		}
 	}
 
-	if (cv_usejoystick.value && joy_open(cv_usejoystick.value) != -1)
+	if (cv_usejoystick.value)
+		newjoy = SDL_JoystickOpen(cv_usejoystick.value-1);
+
+	if (newjoy && JoyInfo2.dev == newjoy) // don't override an active device
+		cv_usejoystick.value = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
+	else if (newjoy && joy_open(cv_usejoystick.value) != -1)
 	{
 		// SDL's device indexes are unstable, so cv_usejoystick may not match
 		// the actual device index. So let's cheat a bit and find the device's current index.
 		JoyInfo.oldjoy = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
 		joystick_started = 1;
-
-		// If another joystick occupied this device, deactivate that joystick
-		if (JoyInfo2.dev == JoyInfo.dev)
-		{
-			CONS_Debug(DBG_GAMELOGIC, "Joystick2 was set to the same device; disabling...\n");
-			cv_usejoystick2.value = 0;
-			I_InitJoystick2();
-		}
 	}
 	else
 	{
@@ -1431,10 +1430,15 @@ void I_InitJoystick(void)
 		cv_usejoystick.value = 0;
 		joystick_started = 0;
 	}
+
+	if (JoyInfo.dev != newjoy && JoyInfo2.dev != newjoy)
+		SDL_JoystickClose(newjoy);
 }
 
 void I_InitJoystick2(void)
 {
+	SDL_Joystick *newjoy = NULL;
+
 	//I_ShutdownJoystick2();
 	if (M_CheckParm("-nojoy"))
 		return;
@@ -1450,20 +1454,17 @@ void I_InitJoystick2(void)
 		}
 	}
 
-	if (cv_usejoystick2.value && joy_open2(cv_usejoystick2.value) != -1)
+	if (cv_usejoystick2.value)
+		newjoy = SDL_JoystickOpen(cv_usejoystick2.value-1);
+
+	if (newjoy && JoyInfo.dev == newjoy) // don't override an active device
+		cv_usejoystick2.value = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
+	else if (newjoy && joy_open2(cv_usejoystick2.value) != -1)
 	{
-		// SDL's device indexes are unstable, so cv_usejoystick2 may not match
+		// SDL's device indexes are unstable, so cv_usejoystick may not match
 		// the actual device index. So let's cheat a bit and find the device's current index.
 		JoyInfo2.oldjoy = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
 		joystick2_started = 1;
-
-		// If another joystick occupied this device, deactivate that joystick
-		if (JoyInfo.dev == JoyInfo2.dev)
-		{
-			CONS_Debug(DBG_GAMELOGIC, "Joystick1 was set to the same device; disabling...\n");
-			cv_usejoystick.value = 0;
-			I_InitJoystick();
-		}
 	}
 	else
 	{
@@ -1473,6 +1474,8 @@ void I_InitJoystick2(void)
 		joystick2_started = 0;
 	}
 
+	if (JoyInfo.dev != newjoy && JoyInfo2.dev != newjoy)
+		SDL_JoystickClose(newjoy);
 }
 
 static void I_ShutdownInput(void)

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -845,7 +845,7 @@ static UINT64 lastjoyhats = 0;
 
 
 */
-static void I_ShutdownJoystick(void)
+void I_ShutdownJoystick(void)
 {
 	INT32 i;
 	event_t event;
@@ -879,14 +879,8 @@ static void I_ShutdownJoystick(void)
 
 	joystick_started = 0;
 	JoyReset(&JoyInfo);
-	if (!joystick_started && !joystick2_started && SDL_WasInit(SDL_INIT_JOYSTICK) == SDL_INIT_JOYSTICK)
-	{
-		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-		if (cv_usejoystick.value == 0)
-		{
-			I_OutputMsg("I_Joystick: SDL's Joystick system has been shutdown\n");
-		}
-	}
+
+	// don't shut down the subsystem here, because hotplugging
 }
 
 void I_GetJoystickEvents(void)
@@ -1033,37 +1027,20 @@ static int joy_open(const char *fname)
 	int num_joy = 0;
 	int i;
 
-	if (joystick_started == 0 && joystick2_started == 0)
+	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
-		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
-		{
-			CONS_Printf(M_GetText("Couldn't initialize joystick: %s\n"), SDL_GetError());
-			return -1;
-		}
-		else
-		{
-			num_joy = SDL_NumJoysticks();
-		}
+		CONS_Printf(M_GetText("Joystick subsystem not started\n"));
+		return -1;
+	}
 
-		if (num_joy < joyindex)
-		{
-			CONS_Printf(M_GetText("Cannot use joystick #%d/(%s), it doesn't exist\n"),joyindex,fname);
-			for (i = 0; i < num_joy; i++)
-				CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
-			I_ShutdownJoystick();
-			return -1;
-		}
-	}
-	else
-	{
-		JoyReset(&JoyInfo);
-		//I_ShutdownJoystick();
-		//joy_open(fname);
-	}
+	JoyReset(&JoyInfo);
+
+	if (joyindex <= 0)
+		return 0;
 
 	num_joy = SDL_NumJoysticks();
 
-	if (joyindex <= 0 || num_joy == 0 || JoyInfo.oldjoy == joyindex)
+	if (num_joy == 0 || JoyInfo.oldjoy == joyindex)
 	{
 //		I_OutputMsg("Unable to use that joystick #(%s), non-number\n",fname);
 		if (num_joy != 0)
@@ -1071,10 +1048,20 @@ static int joy_open(const char *fname)
 			CONS_Printf(M_GetText("Found %d joysticks on this system\n"), num_joy);
 			for (i = 0; i < num_joy; i++)
 				CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
+
+			if (num_joy < joyindex)
+			{
+				CONS_Printf(M_GetText("Cannot use joystick #%d/(%s), it doesn't exist\n"),joyindex,fname);
+				for (i = 0; i < num_joy; i++)
+					CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
+				return 0;
+			}
 		}
 		else
+		{
 			CONS_Printf("%s", M_GetText("Found no joysticks on this system\n"));
-		if (joyindex <= 0 || num_joy == 0) return 0;
+			return 0;
+		}
 	}
 
 	JoyInfo.dev = SDL_JoystickOpen(joyindex-1);
@@ -1082,7 +1069,6 @@ static int joy_open(const char *fname)
 	if (JoyInfo.dev == NULL)
 	{
 		CONS_Printf(M_GetText("Couldn't open joystick: %s\n"), SDL_GetError());
-		I_ShutdownJoystick();
 		return -1;
 	}
 	else
@@ -1094,7 +1080,6 @@ static int joy_open(const char *fname)
 /*		if (joyaxes<2)
 		{
 			I_OutputMsg("Not enought axes?\n");
-			I_ShutdownJoystick();
 			return 0;
 		}*/
 
@@ -1129,7 +1114,7 @@ static UINT64 lastjoy2hats = 0;
 
 	\return	void
 */
-static void I_ShutdownJoystick2(void)
+void I_ShutdownJoystick2(void)
 {
 	INT32 i;
 	event_t event;
@@ -1163,14 +1148,8 @@ static void I_ShutdownJoystick2(void)
 
 	joystick2_started = 0;
 	JoyReset(&JoyInfo2);
-	if (!joystick_started && !joystick2_started && SDL_WasInit(SDL_INIT_JOYSTICK) == SDL_INIT_JOYSTICK)
-	{
-		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-		if (cv_usejoystick2.value == 0)
-		{
-			DEBFILE("I_Joystick2: SDL's Joystick system has been shutdown\n");
-		}
-	}
+
+	// don't shut down the subsystem here, because hotplugging
 }
 
 void I_GetJoystick2Events(void)
@@ -1319,35 +1298,20 @@ static int joy_open2(const char *fname)
 	int num_joy = 0;
 	int i;
 
-	if (joystick_started == 0 && joystick2_started == 0)
+	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
-		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
-		{
-			CONS_Printf(M_GetText("Couldn't initialize joystick: %s\n"), SDL_GetError());
-			return -1;
-		}
-		else
-			num_joy = SDL_NumJoysticks();
+		CONS_Printf(M_GetText("Joystick subsystem not started\n"));
+		return -1;
+	}
 
-		if (num_joy < joyindex)
-		{
-			CONS_Printf(M_GetText("Cannot use joystick #%d/(%s), it doesn't exist\n"),joyindex,fname);
-			for (i = 0; i < num_joy; i++)
-				CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
-			I_ShutdownJoystick2();
-			return -1;
-		}
-	}
-	else
-	{
-		JoyReset(&JoyInfo2);
-		//I_ShutdownJoystick();
-		//joy_open(fname);
-	}
+	JoyReset(&JoyInfo2);
+
+	if (joyindex <= 0)
+		return 0;
 
 	num_joy = SDL_NumJoysticks();
 
-	if (joyindex <= 0 || num_joy == 0 || JoyInfo2.oldjoy == joyindex)
+	if (num_joy == 0 || JoyInfo2.oldjoy == joyindex)
 	{
 //		I_OutputMsg("Unable to use that joystick #(%s), non-number\n",fname);
 		if (num_joy != 0)
@@ -1355,18 +1319,27 @@ static int joy_open2(const char *fname)
 			CONS_Printf(M_GetText("Found %d joysticks on this system\n"), num_joy);
 			for (i = 0; i < num_joy; i++)
 				CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
+
+			if (num_joy < joyindex)
+			{
+				CONS_Printf(M_GetText("Cannot use joystick #%d/(%s), it doesn't exist\n"),joyindex,fname);
+				for (i = 0; i < num_joy; i++)
+					CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
+				return 0;
+			}
 		}
 		else
+		{
 			CONS_Printf("%s", M_GetText("Found no joysticks on this system\n"));
-		if (joyindex <= 0 || num_joy == 0) return 0;
+			return 0;
+		}
 	}
 
 	JoyInfo2.dev = SDL_JoystickOpen(joyindex-1);
 
-	if (!JoyInfo2.dev)
+	if (JoyInfo2.dev == NULL)
 	{
 		CONS_Printf(M_GetText("Couldn't open joystick2: %s\n"), SDL_GetError());
-		I_ShutdownJoystick2();
 		return -1;
 	}
 	else
@@ -1375,10 +1348,9 @@ static int joy_open2(const char *fname)
 		JoyInfo2.axises = SDL_JoystickNumAxes(JoyInfo2.dev);
 		if (JoyInfo2.axises > JOYAXISSET*2)
 			JoyInfo2.axises = JOYAXISSET*2;
-/*		if (joyaxes < 2)
+/*		if (joyaxes<2)
 		{
 			I_OutputMsg("Not enought axes?\n");
-			I_ShutdownJoystick2();
 			return 0;
 		}*/
 
@@ -1403,69 +1375,89 @@ static int joy_open2(const char *fname)
 //
 void I_InitJoystick(void)
 {
-	I_ShutdownJoystick();
-
-	if (M_CheckParm("-noxinput"))
-		SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
-
-	if (M_CheckParm("-nohidapi"))
-		SDL_SetHintWithPriority("SDL_JOYSTICK_HIDAPI", "0", SDL_HINT_OVERRIDE);
-
-	if (!strcmp(cv_usejoystick.string, "0") || M_CheckParm("-nojoy"))
+	//I_ShutdownJoystick();
+	if (M_CheckParm("-nojoy"))
 		return;
-	if (joy_open(cv_usejoystick.string) != -1)
+
+	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
+	{
+		CONS_Printf("Initing joy system\n");
+		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
+		{
+			CONS_Printf(M_GetText("Couldn't initialize joystick: %s\n"), SDL_GetError());
+			return;
+		}
+		else
+			SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
+	}
+
+	if (strcmp(cv_usejoystick.string, "0") && joy_open(cv_usejoystick.string) != -1)
+	{
 		JoyInfo.oldjoy = atoi(cv_usejoystick.string);
+		joystick_started = 1;
+	}
 	else
 	{
+		if (JoyInfo.oldjoy)
+			I_ShutdownJoystick();
 		cv_usejoystick.value = 0;
-		return;
+		joystick_started = 0;
 	}
-	joystick_started = 1;
 }
 
 void I_InitJoystick2(void)
 {
-	I_ShutdownJoystick2();
-
-	if (M_CheckParm("-noxinput"))
-		SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
-
-	if (M_CheckParm("-nohidapi"))
-		SDL_SetHintWithPriority("SDL_JOYSTICK_HIDAPI", "0", SDL_HINT_OVERRIDE);
-
-	if (!strcmp(cv_usejoystick2.string, "0") || M_CheckParm("-nojoy"))
+	//I_ShutdownJoystick2();
+	if (M_CheckParm("-nojoy"))
 		return;
-	if (joy_open2(cv_usejoystick2.string) != -1)
+
+	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
+	{
+		CONS_Printf("Initing joy system\n");
+		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
+		{
+			CONS_Printf(M_GetText("Couldn't initialize joystick: %s\n"), SDL_GetError());
+			return;
+		}
+		else
+			SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
+	}
+
+	if (strcmp(cv_usejoystick2.string, "0") && joy_open2(cv_usejoystick2.string) != -1)
+	{
 		JoyInfo2.oldjoy = atoi(cv_usejoystick2.string);
+		joystick2_started = 1;
+	}
 	else
 	{
+		if (JoyInfo2.oldjoy)
+			I_ShutdownJoystick2();
 		cv_usejoystick2.value = 0;
-		return;
+		joystick2_started = 0;
 	}
-	joystick2_started = 1;
+
 }
 
 static void I_ShutdownInput(void)
 {
+	// Yes, the name is misleading: these send neutral events to
+	// clean up the unplugged joystick's input
+	// Note these methods are internal to this file, not called elsewhere.
+	I_ShutdownJoystick();
+	I_ShutdownJoystick2();
+
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == SDL_INIT_JOYSTICK)
 	{
-		JoyReset(&JoyInfo);
-		JoyReset(&JoyInfo2);
+		CONS_Printf("Shutting down joy system\n");
 		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+		I_OutputMsg("I_Joystick: SDL's Joystick system has been shutdown\n");
 	}
-
 }
 
 INT32 I_NumJoys(void)
 {
 	INT32 numjoy = 0;
-	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
-	{
-		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) != -1)
-			numjoy = SDL_NumJoysticks();
-		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-	}
-	else
+	if (SDL_WasInit(SDL_INIT_JOYSTICK) == SDL_INIT_JOYSTICK)
 		numjoy = SDL_NumJoysticks();
 	return numjoy;
 }
@@ -1475,18 +1467,9 @@ static char joyname[255]; // MAX_PATH; joystick name is straight from the driver
 const char *I_GetJoyName(INT32 joyindex)
 {
 	const char *tempname = NULL;
+	joyname[0] = 0;
 	joyindex--; //SDL's Joystick System starts at 0, not 1
-	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
-	{
-		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) != -1)
-		{
-			tempname = SDL_JoystickNameForIndex(joyindex);
-			if (tempname)
-				strncpy(joyname, tempname, sizeof(joyname)-1);
-		}
-		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-	}
-	else
+	if (SDL_WasInit(SDL_INIT_JOYSTICK) == SDL_INIT_JOYSTICK)
 	{
 		tempname = SDL_JoystickNameForIndex(joyindex);
 		if (tempname)

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1090,12 +1090,12 @@ static int joy_open(const char *fname)
 
 	if (JoyInfo.dev == NULL)
 	{
-		CONS_Printf(M_GetText("Couldn't open joystick: %s\n"), SDL_GetError());
+		CONS_Debug(DBG_GAMELOGIC, M_GetText("Joystick1: Couldn't open device - %s\n"), SDL_GetError());
 		return -1;
 	}
 	else
 	{
-		CONS_Printf(M_GetText("Joystick: %s\n"), SDL_JoystickName(JoyInfo.dev));
+		CONS_Debug(DBG_GAMELOGIC, M_GetText("Joystick1: %s\n"), SDL_JoystickName(JoyInfo.dev));
 		JoyInfo.axises = SDL_JoystickNumAxes(JoyInfo.dev);
 		if (JoyInfo.axises > JOYAXISSET*2)
 			JoyInfo.axises = JOYAXISSET*2;
@@ -1383,12 +1383,12 @@ static int joy_open2(const char *fname)
 
 	if (JoyInfo2.dev == NULL)
 	{
-		CONS_Printf(M_GetText("Couldn't open joystick2: %s\n"), SDL_GetError());
+		CONS_Debug(DBG_GAMELOGIC, M_GetText("Joystick2: couldn't open device - %s\n"), SDL_GetError());
 		return -1;
 	}
 	else
 	{
-		CONS_Printf(M_GetText("Joystick2: %s\n"), SDL_JoystickName(JoyInfo2.dev));
+		CONS_Debug(DBG_GAMELOGIC, M_GetText("Joystick2: %s\n"), SDL_JoystickName(JoyInfo2.dev));
 		JoyInfo2.axises = SDL_JoystickNumAxes(JoyInfo2.dev);
 		if (JoyInfo2.axises > JOYAXISSET*2)
 			JoyInfo2.axises = JOYAXISSET*2;
@@ -1445,7 +1445,11 @@ void I_InitJoystick(void)
 		if (JoyInfo.oldjoy <= 0)
 			JoyInfo.oldjoy = atoi(cv_usejoystick.string);
 		else
+		{
+			CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index has changed: was %d, now %d\n",
+				JoyInfo.oldjoy, SDL_JoystickInstanceID(JoyInfo.dev) + 1);
 			JoyInfo.oldjoy = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
+		}
 		joystick_started = 1;
 	}
 	else
@@ -1485,7 +1489,11 @@ void I_InitJoystick2(void)
 		if (JoyInfo2.oldjoy <= 0)
 			JoyInfo2.oldjoy = atoi(cv_usejoystick2.string);
 		else
+		{
+			CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index has changed: was %d, now %d\n",
+				JoyInfo2.oldjoy, SDL_JoystickInstanceID(JoyInfo2.dev) + 1);
 			JoyInfo2.oldjoy = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
+		}
 		joystick2_started = 1;
 	}
 	else

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1026,7 +1026,6 @@ static int joy_open(const char *fname)
 	SDL_Joystick *newdev = NULL;
 	int joyindex = atoi(fname);
 	int num_joy = 0;
-	int i;
 
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
@@ -1034,35 +1033,15 @@ static int joy_open(const char *fname)
 		return -1;
 	}
 
-	JoyReset(&JoyInfo);
-
 	if (joyindex <= 0)
-		return 0;
+		return -1;
 
 	num_joy = SDL_NumJoysticks();
 
-	if (num_joy == 0 || JoyInfo.oldjoy == joyindex)
+	if (num_joy == 0)
 	{
-//		I_OutputMsg("Unable to use that joystick #(%s), non-number\n",fname);
-		if (num_joy != 0)
-		{
-			CONS_Printf(M_GetText("Found %d joysticks on this system\n"), num_joy);
-			for (i = 0; i < num_joy; i++)
-				CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
-
-			if (num_joy < joyindex)
-			{
-				CONS_Printf(M_GetText("Cannot use joystick #%d/(%s), it doesn't exist\n"),joyindex,fname);
-				for (i = 0; i < num_joy; i++)
-					CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
-				return 0;
-			}
-		}
-		else
-		{
-			CONS_Printf("%s", M_GetText("Found no joysticks on this system\n"));
-			return 0;
-		}
+		CONS_Printf("%s", M_GetText("Found no joysticks on this system\n"));
+		return -1;
 	}
 
 	newdev = SDL_JoystickOpen(joyindex-1);
@@ -1083,6 +1062,7 @@ static int joy_open(const char *fname)
 			|| (newdev == NULL && SDL_JoystickGetAttached(JoyInfo.dev))) // we failed, but already have a working device
 			return JoyInfo.axises;
 		// Else, we're changing devices, so send neutral joy events
+		CONS_Debug(DBG_GAMELOGIC, "Joystick1 device is changing; resetting events...\n");
 		I_ShutdownJoystick();
 	}
 
@@ -1319,7 +1299,6 @@ static int joy_open2(const char *fname)
 	SDL_Joystick *newdev = NULL;
 	int joyindex = atoi(fname);
 	int num_joy = 0;
-	int i;
 
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
@@ -1327,35 +1306,15 @@ static int joy_open2(const char *fname)
 		return -1;
 	}
 
-	JoyReset(&JoyInfo2);
-
 	if (joyindex <= 0)
-		return 0;
+		return -1;
 
 	num_joy = SDL_NumJoysticks();
 
-	if (num_joy == 0 || JoyInfo2.oldjoy == joyindex)
+	if (num_joy == 0)
 	{
-//		I_OutputMsg("Unable to use that joystick #(%s), non-number\n",fname);
-		if (num_joy != 0)
-		{
-			CONS_Printf(M_GetText("Found %d joysticks on this system\n"), num_joy);
-			for (i = 0; i < num_joy; i++)
-				CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
-
-			if (num_joy < joyindex)
-			{
-				CONS_Printf(M_GetText("Cannot use joystick #%d/(%s), it doesn't exist\n"),joyindex,fname);
-				for (i = 0; i < num_joy; i++)
-					CONS_Printf("#%d/(%s)\n", i+1, SDL_JoystickNameForIndex(i));
-				return 0;
-			}
-		}
-		else
-		{
-			CONS_Printf("%s", M_GetText("Found no joysticks on this system\n"));
-			return 0;
-		}
+		CONS_Printf("%s", M_GetText("Found no joysticks on this system\n"));
+		return -1;
 	}
 
 	newdev = SDL_JoystickOpen(joyindex-1);
@@ -1376,6 +1335,7 @@ static int joy_open2(const char *fname)
 			|| (newdev == NULL && SDL_JoystickGetAttached(JoyInfo2.dev))) // we failed, but already have a working device
 			return JoyInfo.axises;
 		// Else, we're changing devices, so send neutral joy events
+		CONS_Debug(DBG_GAMELOGIC, "Joystick2 device is changing; resetting events...\n");
 		I_ShutdownJoystick2();
 	}
 
@@ -1436,20 +1396,7 @@ void I_InitJoystick(void)
 
 	if (strcmp(cv_usejoystick.string, "0") && joy_open(cv_usejoystick.string) != -1)
 	{
-		// JoyInfo.oldjoy may already be filled because we attempted to hotplug
-		// a device and the device index has changed
-		// So in this case, get the new device index
-		//
-		// For now, it does not actually matter if the JoyInfo.oldjoy value is inaccurate. We don't use its
-		// exact value; we just use it like a boolean.
-		if (JoyInfo.oldjoy <= 0)
-			JoyInfo.oldjoy = atoi(cv_usejoystick.string);
-		else
-		{
-			CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index has changed: was %d, now %d\n",
-				JoyInfo.oldjoy, SDL_JoystickInstanceID(JoyInfo.dev) + 1);
-			JoyInfo.oldjoy = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
-		}
+		JoyInfo.oldjoy = atoi(cv_usejoystick.string);
 		joystick_started = 1;
 	}
 	else
@@ -1480,20 +1427,7 @@ void I_InitJoystick2(void)
 
 	if (strcmp(cv_usejoystick2.string, "0") && joy_open2(cv_usejoystick2.string) != -1)
 	{
-		// JoyInfo.oldjoy may already be filled because we attempted to hotplug
-		// a device and the device index has changed
-		// So in this case, get the new device index
-		//
-		// For now, it does not actually matter if the JoyInfo2.oldjoy value is inaccurate. We don't use its
-		// exact value; we just use it like a boolean.
-		if (JoyInfo2.oldjoy <= 0)
-			JoyInfo2.oldjoy = atoi(cv_usejoystick2.string);
-		else
-		{
-			CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index has changed: was %d, now %d\n",
-				JoyInfo2.oldjoy, SDL_JoystickInstanceID(JoyInfo2.dev) + 1);
-			JoyInfo2.oldjoy = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
-		}
+		JoyInfo2.oldjoy = atoi(cv_usejoystick2.string);
 		joystick2_started = 1;
 	}
 	else

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1415,11 +1415,20 @@ void I_InitJoystick(void)
 		// the actual device index. So let's cheat a bit and find the device's current index.
 		JoyInfo.oldjoy = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
 		joystick_started = 1;
+
+		// If another joystick occupied this device, deactivate that joystick
+		if (JoyInfo2.dev == JoyInfo.dev)
+		{
+			CONS_Debug(DBG_GAMELOGIC, "Joystick2 was set to the same device; disabling...\n");
+			cv_usejoystick2.value = 0;
+			I_InitJoystick2();
+		}
 	}
 	else
 	{
 		if (JoyInfo.oldjoy)
 			I_ShutdownJoystick();
+		cv_usejoystick.value = 0;
 		joystick_started = 0;
 	}
 }
@@ -1447,11 +1456,20 @@ void I_InitJoystick2(void)
 		// the actual device index. So let's cheat a bit and find the device's current index.
 		JoyInfo2.oldjoy = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
 		joystick2_started = 1;
+
+		// If another joystick occupied this device, deactivate that joystick
+		if (JoyInfo.dev == JoyInfo2.dev)
+		{
+			CONS_Debug(DBG_GAMELOGIC, "Joystick1 was set to the same device; disabling...\n");
+			cv_usejoystick.value = 0;
+			I_InitJoystick();
+		}
 	}
 	else
 	{
 		if (JoyInfo2.oldjoy)
 			I_ShutdownJoystick2();
+		cv_usejoystick2.value = 0;
 		joystick2_started = 0;
 	}
 

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1402,7 +1402,7 @@ void I_InitJoystick(void)
 
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
-		CONS_Printf("Initing joy system\n");
+		CONS_Printf("I_InitJoystick()...\n");
 		SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
 		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
 		{
@@ -1445,7 +1445,7 @@ void I_InitJoystick2(void)
 
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
-		CONS_Printf("Initing joy system\n");
+		CONS_Printf("I_InitJoystick2()...\n");
 		SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
 		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
 		{

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1021,10 +1021,9 @@ void I_GetJoystickEvents(void)
 
 
 */
-static int joy_open(const char *fname)
+static int joy_open(int joyindex)
 {
 	SDL_Joystick *newdev = NULL;
-	int joyindex = atoi(fname);
 	int num_joy = 0;
 
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
@@ -1294,10 +1293,9 @@ void I_GetJoystick2Events(void)
 
 
 */
-static int joy_open2(const char *fname)
+static int joy_open2(int joyindex)
 {
 	SDL_Joystick *newdev = NULL;
-	int joyindex = atoi(fname);
 	int num_joy = 0;
 
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
@@ -1394,16 +1392,18 @@ void I_InitJoystick(void)
 		}
 	}
 
-	if (strcmp(cv_usejoystick.string, "0") && joy_open(cv_usejoystick.string) != -1)
+	if (cv_usejoystick.value && joy_open(cv_usejoystick.value) != -1)
 	{
-		JoyInfo.oldjoy = atoi(cv_usejoystick.string);
+		// SDL's device indexes are unstable, so cv_usejoystick may not match
+		// the actual device index. So let's cheat a bit and use the instance ID.
+		// oldjoy's exact value doesn't matter, because we use it like a boolean
+		JoyInfo.oldjoy = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
 		joystick_started = 1;
 	}
 	else
 	{
 		if (JoyInfo.oldjoy)
 			I_ShutdownJoystick();
-		cv_usejoystick.value = 0;
 		joystick_started = 0;
 	}
 }
@@ -1425,16 +1425,18 @@ void I_InitJoystick2(void)
 		}
 	}
 
-	if (strcmp(cv_usejoystick2.string, "0") && joy_open2(cv_usejoystick2.string) != -1)
+	if (cv_usejoystick2.value && joy_open2(cv_usejoystick2.value) != -1)
 	{
-		JoyInfo2.oldjoy = atoi(cv_usejoystick2.string);
+		// SDL's device indexes are unstable, so cv_usejoystick2 may not match
+		// the actual device index. So let's cheat a bit and use the instance ID.
+		// oldjoy's exact value doesn't matter, because we use it like a boolean
+		JoyInfo2.oldjoy = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
 		joystick2_started = 1;
 	}
 	else
 	{
 		if (JoyInfo2.oldjoy)
 			I_ShutdownJoystick2();
-		cv_usejoystick2.value = 0;
 		joystick2_started = 0;
 	}
 

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1023,6 +1023,7 @@ void I_GetJoystickEvents(void)
 */
 static int joy_open(const char *fname)
 {
+	SDL_Joystick *newdev = NULL;
 	int joyindex = atoi(fname);
 	int num_joy = 0;
 	int i;
@@ -1064,7 +1065,28 @@ static int joy_open(const char *fname)
 		}
 	}
 
-	JoyInfo.dev = SDL_JoystickOpen(joyindex-1);
+	newdev = SDL_JoystickOpen(joyindex-1);
+
+	// Handle the edge case where the device <-> joystick index assignment can change due to hotplugging
+	// This indexing is SDL's responsibility and there's not much we can do about it.
+	//
+	// Example:
+	// 1. Plug Controller A   -> Index 0 opened
+	// 2. Plug Controller B   -> Index 1 opened
+	// 3. Unplug Controller A -> Index 0 closed, Index 1 active
+	// 4. Unplug Controller B -> Index 0 inactive, Index 1 closed
+	// 5. Plug Controller B   -> Index 0 opened
+	// 6. Plug Controller A   -> Index 0 REPLACED, opened as Controller A; Index 1 is now Controller B
+	if (JoyInfo.dev)
+	{
+		if (JoyInfo.dev == newdev // same device, nothing to do
+			|| (newdev == NULL && SDL_JoystickGetAttached(JoyInfo.dev))) // we failed, but already have a working device
+			return JoyInfo.axises;
+		// Else, we're changing devices, so send neutral joy events
+		I_ShutdownJoystick();
+	}
+
+	JoyInfo.dev = newdev;
 
 	if (JoyInfo.dev == NULL)
 	{
@@ -1077,7 +1099,7 @@ static int joy_open(const char *fname)
 		JoyInfo.axises = SDL_JoystickNumAxes(JoyInfo.dev);
 		if (JoyInfo.axises > JOYAXISSET*2)
 			JoyInfo.axises = JOYAXISSET*2;
-/*		if (joyaxes<2)
+	/*		if (joyaxes<2)
 		{
 			I_OutputMsg("Not enought axes?\n");
 			return 0;
@@ -1294,6 +1316,7 @@ void I_GetJoystick2Events(void)
 */
 static int joy_open2(const char *fname)
 {
+	SDL_Joystick *newdev = NULL;
 	int joyindex = atoi(fname);
 	int num_joy = 0;
 	int i;
@@ -1335,7 +1358,28 @@ static int joy_open2(const char *fname)
 		}
 	}
 
-	JoyInfo2.dev = SDL_JoystickOpen(joyindex-1);
+	newdev = SDL_JoystickOpen(joyindex-1);
+
+	// Handle the edge case where the device <-> joystick index assignment can change due to hotplugging
+	// This indexing is SDL's responsibility and there's not much we can do about it.
+	//
+	// Example:
+	// 1. Plug Controller A   -> Index 0 opened
+	// 2. Plug Controller B   -> Index 1 opened
+	// 3. Unplug Controller A -> Index 0 closed, Index 1 active
+	// 4. Unplug Controller B -> Index 0 inactive, Index 1 closed
+	// 5. Plug Controller B   -> Index 0 opened
+	// 6. Plug Controller A   -> Index 0 REPLACED, opened as Controller A; Index 1 is now Controller B
+	if (JoyInfo2.dev)
+	{
+		if (JoyInfo2.dev == newdev // same device, nothing to do
+			|| (newdev == NULL && SDL_JoystickGetAttached(JoyInfo2.dev))) // we failed, but already have a working device
+			return JoyInfo.axises;
+		// Else, we're changing devices, so send neutral joy events
+		I_ShutdownJoystick2();
+	}
+
+	JoyInfo2.dev = newdev;
 
 	if (JoyInfo2.dev == NULL)
 	{
@@ -1392,7 +1436,16 @@ void I_InitJoystick(void)
 
 	if (strcmp(cv_usejoystick.string, "0") && joy_open(cv_usejoystick.string) != -1)
 	{
-		JoyInfo.oldjoy = atoi(cv_usejoystick.string);
+		// JoyInfo.oldjoy may already be filled because we attempted to hotplug
+		// a device and the device index has changed
+		// So in this case, get the new device index
+		//
+		// For now, it does not actually matter if the JoyInfo.oldjoy value is inaccurate. We don't use its
+		// exact value; we just use it like a boolean.
+		if (JoyInfo.oldjoy <= 0)
+			JoyInfo.oldjoy = atoi(cv_usejoystick.string);
+		else
+			JoyInfo.oldjoy = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
 		joystick_started = 1;
 	}
 	else
@@ -1423,7 +1476,16 @@ void I_InitJoystick2(void)
 
 	if (strcmp(cv_usejoystick2.string, "0") && joy_open2(cv_usejoystick2.string) != -1)
 	{
-		JoyInfo2.oldjoy = atoi(cv_usejoystick2.string);
+		// JoyInfo.oldjoy may already be filled because we attempted to hotplug
+		// a device and the device index has changed
+		// So in this case, get the new device index
+		//
+		// For now, it does not actually matter if the JoyInfo2.oldjoy value is inaccurate. We don't use its
+		// exact value; we just use it like a boolean.
+		if (JoyInfo2.oldjoy <= 0)
+			JoyInfo2.oldjoy = atoi(cv_usejoystick2.string);
+		else
+			JoyInfo2.oldjoy = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
 		joystick2_started = 1;
 	}
 	else

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -1382,13 +1382,12 @@ void I_InitJoystick(void)
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
 		CONS_Printf("Initing joy system\n");
+		SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
 		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
 		{
 			CONS_Printf(M_GetText("Couldn't initialize joystick: %s\n"), SDL_GetError());
 			return;
 		}
-		else
-			SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
 	}
 
 	if (strcmp(cv_usejoystick.string, "0") && joy_open(cv_usejoystick.string) != -1)
@@ -1414,13 +1413,12 @@ void I_InitJoystick2(void)
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) == 0)
 	{
 		CONS_Printf("Initing joy system\n");
+		SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
 		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
 		{
 			CONS_Printf(M_GetText("Couldn't initialize joystick: %s\n"), SDL_GetError());
 			return;
 		}
-		else
-			SDL_SetHintWithPriority("SDL_XINPUT_ENABLED", "0", SDL_HINT_OVERRIDE);
 	}
 
 	if (strcmp(cv_usejoystick2.string, "0") && joy_open2(cv_usejoystick2.string) != -1)

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -121,6 +121,9 @@ static      INT32          firstEntry = 0;
 // Total mouse motion X/Y offsets
 static      INT32        mousemovex = 0, mousemovey = 0;
 
+// Keep track of joy unplugged count
+static      INT32        joyunplugcount = 0;
+
 // SDL vars
 static      SDL_Surface *vidSurface = NULL;
 static      SDL_Surface *bufSurface = NULL;
@@ -933,6 +936,38 @@ void I_GetEvent(void)
 			case SDL_JOYBUTTONDOWN:
 				Impl_HandleJoystickButtonEvent(evt.jbutton, evt.type);
 				break;
+			case SDL_JOYDEVICEADDED:
+				CONS_Printf("Joy device %d added\n", evt.jdevice.which);
+
+				// recounts hotplugged joysticks
+				I_InitJoystick();
+				I_InitJoystick2();
+
+				// update the menu
+				if (currentMenu == &OP_JoystickSetDef)
+					M_SetupJoystickMenu(0);
+				break;
+			case SDL_JOYDEVICEREMOVED:
+				{
+					// every time a device is unplugged, the "which" index increments by 1?
+					INT32 deviceIdx = evt.jdevice.which - joyunplugcount++;
+
+					CONS_Printf("Joy device %d removed%s\n", deviceIdx,
+						(JoyInfo.oldjoy-1 == deviceIdx) ? " was first joystick" :
+						(JoyInfo2.oldjoy-1 == deviceIdx) ? " was second joystick" : "");
+
+					// I_ShutdownJoystick doesn't shut down the subsystem
+					// It just fires neutral joy events to clean up the unplugged joy
+					if (JoyInfo.oldjoy-1 == deviceIdx)
+						I_ShutdownJoystick();
+					if (JoyInfo2.oldjoy-1 == deviceIdx)
+						I_ShutdownJoystick2();
+
+					// update the menu
+					if (currentMenu == &OP_JoystickSetDef)
+						M_SetupJoystickMenu(0);
+				}
+			 	break;
 			case SDL_QUIT:
 				I_Quit();
 				M_QuitResponse('y');

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -934,69 +934,78 @@ void I_GetEvent(void)
 				Impl_HandleJoystickButtonEvent(evt.jbutton, evt.type);
 				break;
 			case SDL_JOYDEVICEADDED:
-				CONS_Debug(DBG_GAMELOGIC, "Joystick device index %d added\n", evt.jdevice.which + 1);
-
-				// Because SDL's device index is unstable, we're going to cheat here a bit:
-				// For the first joystick setting that is NOT active:
-				// 1. Set cv_usejoystickX.value to the new device index (this does not change what is written to config.cfg)
-				// 2. Set OTHERS' cv_usejoystickX.value to THEIR new device index, because it likely changed
-				//    * If device doesn't exist, switch cv_usejoystick back to default value (.string)
-				//      * BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
-				if (!JoyInfo.dev || !SDL_JoystickGetAttached(JoyInfo.dev))
 				{
-					cv_usejoystick.value = evt.jdevice.which + 1;
+					SDL_Joystick *newjoy = SDL_JoystickOpen(evt.jdevice.which);
 
-					if (JoyInfo2.dev)
-						cv_usejoystick2.value = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
-					else if (atoi(cv_usejoystick2.string) != JoyInfo.oldjoy
-					         && atoi(cv_usejoystick2.string) != cv_usejoystick.value)
-						cv_usejoystick2.value = atoi(cv_usejoystick2.string);
-					else if (atoi(cv_usejoystick.string) != JoyInfo.oldjoy
-					         && atoi(cv_usejoystick.string) != cv_usejoystick.value)
-						cv_usejoystick2.value = atoi(cv_usejoystick.string);
-					else // we tried...
-						cv_usejoystick2.value = 0;
-				}
-				else if (!JoyInfo2.dev || !SDL_JoystickGetAttached(JoyInfo2.dev))
-				{
-					cv_usejoystick2.value = evt.jdevice.which + 1;
+					CONS_Debug(DBG_GAMELOGIC, "Joystick device index %d added\n", evt.jdevice.which + 1);
 
-					if (JoyInfo.dev)
-						cv_usejoystick.value = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
-					else if (atoi(cv_usejoystick.string) != JoyInfo2.oldjoy
-					         && atoi(cv_usejoystick.string) != cv_usejoystick2.value)
-						cv_usejoystick.value = atoi(cv_usejoystick.string);
-					else if (atoi(cv_usejoystick2.string) != JoyInfo2.oldjoy
-					         && atoi(cv_usejoystick2.string) != cv_usejoystick2.value)
-						cv_usejoystick.value = atoi(cv_usejoystick2.string);
-					else // we tried...
+					// Because SDL's device index is unstable, we're going to cheat here a bit:
+					// For the first joystick setting that is NOT active:
+					// 1. Set cv_usejoystickX.value to the new device index (this does not change what is written to config.cfg)
+					// 2. Set OTHERS' cv_usejoystickX.value to THEIR new device index, because it likely changed
+					//    * If device doesn't exist, switch cv_usejoystick back to default value (.string)
+					//      * BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
+					if (newjoy && (!JoyInfo.dev || !SDL_JoystickGetAttached(JoyInfo.dev))
+						&& JoyInfo2.dev != newjoy) // don't override a currently active device
+					{
+						cv_usejoystick.value = evt.jdevice.which + 1;
+
+						if (JoyInfo2.dev)
+							cv_usejoystick2.value = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
+						else if (atoi(cv_usejoystick2.string) != JoyInfo.oldjoy
+								&& atoi(cv_usejoystick2.string) != cv_usejoystick.value)
+							cv_usejoystick2.value = atoi(cv_usejoystick2.string);
+						else if (atoi(cv_usejoystick.string) != JoyInfo.oldjoy
+								&& atoi(cv_usejoystick.string) != cv_usejoystick.value)
+							cv_usejoystick2.value = atoi(cv_usejoystick.string);
+						else // we tried...
+							cv_usejoystick2.value = 0;
+					}
+					else if (newjoy && (!JoyInfo2.dev || !SDL_JoystickGetAttached(JoyInfo2.dev))
+						&& JoyInfo.dev != newjoy) // don't override a currently active device
+					{
+						cv_usejoystick2.value = evt.jdevice.which + 1;
+
+						if (JoyInfo.dev)
+							cv_usejoystick.value = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
+						else if (atoi(cv_usejoystick.string) != JoyInfo2.oldjoy
+								&& atoi(cv_usejoystick.string) != cv_usejoystick2.value)
+							cv_usejoystick.value = atoi(cv_usejoystick.string);
+						else if (atoi(cv_usejoystick2.string) != JoyInfo2.oldjoy
+								&& atoi(cv_usejoystick2.string) != cv_usejoystick2.value)
+							cv_usejoystick.value = atoi(cv_usejoystick2.string);
+						else // we tried...
+							cv_usejoystick.value = 0;
+					}
+
+					// Was cv_usejoystick disabled in settings?
+					if (!strcmp(cv_usejoystick.string, "0") || !cv_usejoystick.value)
 						cv_usejoystick.value = 0;
+					else if (cv_usejoystick.value) // update the cvar ONLY if a device exists
+						CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
+
+					if (!strcmp(cv_usejoystick2.string, "0") || !cv_usejoystick2.value)
+						cv_usejoystick2.value = 0;
+					else if (cv_usejoystick2.value) // update the cvar ONLY if a device exists
+						CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
+
+					// Update all joysticks' init states
+					// This is a little wasteful since cv_usejoystick already calls this, but
+					// we need to do this in case CV_SetValue did nothing because the string was already same.
+					// if the device is already active, this should do nothing, effectively.
+					I_InitJoystick();
+					I_InitJoystick2();
+
+					CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);
+					CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index: %d\n", JoyInfo2.oldjoy);
+
+					// update the menu
+					if (currentMenu == &OP_JoystickSetDef)
+						M_SetupJoystickMenu(0);
+
+					if (JoyInfo.dev != newjoy && JoyInfo2.dev != newjoy)
+						SDL_JoystickClose(newjoy);
 				}
-
-				// Was cv_usejoystick disabled in settings?
-				if (!strcmp(cv_usejoystick.string, "0") || !cv_usejoystick.value)
-					cv_usejoystick.value = 0;
-				else if (cv_usejoystick.value) // update the cvar ONLY if a device exists
-					CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
-
-				if (!strcmp(cv_usejoystick2.string, "0") || !cv_usejoystick2.value)
-					cv_usejoystick2.value = 0;
-				else if (cv_usejoystick2.value) // update the cvar ONLY if a device exists
-					CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
-
-				// Update all joysticks' init states
-				// This is a little wasteful since cv_usejoystick already calls this, but
-				// we need to do this in case CV_SetValue did nothing because the string was already same.
-				// if the device is already active, this should do nothing, effectively.
-				I_InitJoystick();
-				I_InitJoystick2();
-
-				CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);
-				CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index: %d\n", JoyInfo2.oldjoy);
-
-				// update the menu
-				if (currentMenu == &OP_JoystickSetDef)
-					M_SetupJoystickMenu(0);
 				break;
 			case SDL_JOYDEVICEREMOVED:
 				if (JoyInfo.dev && !SDL_JoystickGetAttached(JoyInfo.dev))

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -934,11 +934,14 @@ void I_GetEvent(void)
 				Impl_HandleJoystickButtonEvent(evt.jbutton, evt.type);
 				break;
 			case SDL_JOYDEVICEADDED:
-				CONS_Printf("Joy device %d added\n", evt.jdevice.which);
+				CONS_Debug(DBG_GAMELOGIC, "Joystick device index %d added\n", evt.jdevice.which + 1);
 
-				// recounts hotplugged joysticks
+				// recount hotplugged joysticks
 				I_InitJoystick();
 				I_InitJoystick2();
+
+				CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);
+				CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index: %d\n", JoyInfo2.oldjoy);
 
 				// update the menu
 				if (currentMenu == &OP_JoystickSetDef)
@@ -947,15 +950,18 @@ void I_GetEvent(void)
 			case SDL_JOYDEVICEREMOVED:
 				if (JoyInfo.dev && !SDL_JoystickGetAttached(JoyInfo.dev))
 				{
-					CONS_Printf("Joy device %d removed, was first joystick\n", JoyInfo.oldjoy);
+					CONS_Debug(DBG_GAMELOGIC, "Joystick1 removed, device index: %d\n", JoyInfo.oldjoy);
 					I_ShutdownJoystick();
 				}
 
 				if (JoyInfo2.dev && !SDL_JoystickGetAttached(JoyInfo2.dev))
 				{
-					CONS_Printf("Joy device %d removed, was second joystick\n", JoyInfo2.oldjoy);
+					CONS_Debug(DBG_GAMELOGIC, "Joystick2 removed, device index: %d\n", JoyInfo2.oldjoy);
 					I_ShutdownJoystick2();
 				}
+
+				CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);
+				CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index: %d\n", JoyInfo2.oldjoy);
 
 				// update the menu
 				if (currentMenu == &OP_JoystickSetDef)

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -121,9 +121,6 @@ static      INT32          firstEntry = 0;
 // Total mouse motion X/Y offsets
 static      INT32        mousemovex = 0, mousemovey = 0;
 
-// Keep track of joy unplugged count
-static      INT32        joyunplugcount = 0;
-
 // SDL vars
 static      SDL_Surface *vidSurface = NULL;
 static      SDL_Surface *bufSurface = NULL;
@@ -948,25 +945,21 @@ void I_GetEvent(void)
 					M_SetupJoystickMenu(0);
 				break;
 			case SDL_JOYDEVICEREMOVED:
+				if (JoyInfo.dev && !SDL_JoystickGetAttached(JoyInfo.dev))
 				{
-					// every time a device is unplugged, the "which" index increments by 1?
-					INT32 deviceIdx = evt.jdevice.which - joyunplugcount++;
-
-					CONS_Printf("Joy device %d removed%s\n", deviceIdx,
-						(JoyInfo.oldjoy-1 == deviceIdx) ? " was first joystick" :
-						(JoyInfo2.oldjoy-1 == deviceIdx) ? " was second joystick" : "");
-
-					// I_ShutdownJoystick doesn't shut down the subsystem
-					// It just fires neutral joy events to clean up the unplugged joy
-					if (JoyInfo.oldjoy-1 == deviceIdx)
-						I_ShutdownJoystick();
-					if (JoyInfo2.oldjoy-1 == deviceIdx)
-						I_ShutdownJoystick2();
-
-					// update the menu
-					if (currentMenu == &OP_JoystickSetDef)
-						M_SetupJoystickMenu(0);
+					CONS_Printf("Joy device %d removed, was first joystick\n", JoyInfo.oldjoy);
+					I_ShutdownJoystick();
 				}
+
+				if (JoyInfo2.dev && !SDL_JoystickGetAttached(JoyInfo2.dev))
+				{
+					CONS_Printf("Joy device %d removed, was second joystick\n", JoyInfo2.oldjoy);
+					I_ShutdownJoystick2();
+				}
+
+				// update the menu
+				if (currentMenu == &OP_JoystickSetDef)
+					M_SetupJoystickMenu(0);
 			 	break;
 			case SDL_QUIT:
 				I_Quit();

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -938,19 +938,21 @@ void I_GetEvent(void)
 
 				// Because SDL's device index is unstable, we're going to cheat here a bit:
 				// For the first joystick setting that is NOT active:
-				// Set cv_usejoystickX.value to the new device index (this does not change what is written to config.cfg)
-				// Set OTHERS' cv_usejoystickX.value to THEIR new device index, because it likely changed
-				// If device doesn't exist, switch cv_usejoystick back to default value (.string)
-				// BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
+				// 1. Set cv_usejoystickX.value to the new device index (this does not change what is written to config.cfg)
+				// 2. Set OTHERS' cv_usejoystickX.value to THEIR new device index, because it likely changed
+				//    * If device doesn't exist, switch cv_usejoystick back to default value (.string)
+				//      * BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
 				if (!JoyInfo.dev || !SDL_JoystickGetAttached(JoyInfo.dev))
 				{
 					cv_usejoystick.value = evt.jdevice.which + 1;
 
 					if (JoyInfo2.dev)
 						cv_usejoystick2.value = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
-					else if (atoi(cv_usejoystick2.string) != JoyInfo.oldjoy)
+					else if (atoi(cv_usejoystick2.string) != JoyInfo.oldjoy
+					         && atoi(cv_usejoystick2.string) != cv_usejoystick.value)
 						cv_usejoystick2.value = atoi(cv_usejoystick2.string);
-					else if (atoi(cv_usejoystick.string) != JoyInfo.oldjoy)
+					else if (atoi(cv_usejoystick.string) != JoyInfo.oldjoy
+					         && atoi(cv_usejoystick.string) != cv_usejoystick.value)
 						cv_usejoystick2.value = atoi(cv_usejoystick.string);
 					else // we tried...
 						cv_usejoystick2.value = 0;
@@ -961,16 +963,31 @@ void I_GetEvent(void)
 
 					if (JoyInfo.dev)
 						cv_usejoystick.value = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
-					else if (atoi(cv_usejoystick.string) != JoyInfo2.oldjoy)
+					else if (atoi(cv_usejoystick.string) != JoyInfo2.oldjoy
+					         && atoi(cv_usejoystick.string) != cv_usejoystick2.value)
 						cv_usejoystick.value = atoi(cv_usejoystick.string);
-					else if (atoi(cv_usejoystick2.string) != JoyInfo2.oldjoy)
+					else if (atoi(cv_usejoystick2.string) != JoyInfo2.oldjoy
+					         && atoi(cv_usejoystick2.string) != cv_usejoystick2.value)
 						cv_usejoystick.value = atoi(cv_usejoystick2.string);
 					else // we tried...
 						cv_usejoystick.value = 0;
 				}
 
-				// If an active joystick's index has changed, these will just
-				// change the corresponding JoyInfo.oldjoy
+				// Was cv_usejoystick disabled in settings?
+				if (!strcmp(cv_usejoystick.string, "0") || !cv_usejoystick.value)
+					cv_usejoystick.value = 0;
+				else if (cv_usejoystick.value) // update the cvar ONLY if a device exists
+					CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
+
+				if (!strcmp(cv_usejoystick2.string, "0") || !cv_usejoystick2.value)
+					cv_usejoystick2.value = 0;
+				else if (cv_usejoystick2.value) // update the cvar ONLY if a device exists
+					CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
+
+				// Update all joysticks' init states
+				// This is a little wasteful since cv_usejoystick already calls this, but
+				// we need to do this in case CV_SetValue did nothing because the string was already same.
+				// if the device is already active, this should do nothing, effectively.
 				I_InitJoystick();
 				I_InitJoystick2();
 
@@ -995,8 +1012,8 @@ void I_GetEvent(void)
 				}
 
 				// Update the device indexes, because they likely changed
-				// If device doesn't exist, switch cv_usejoystick back to default value (.string)
-				// BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
+				// * If device doesn't exist, switch cv_usejoystick back to default value (.string)
+				//   * BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
 				if (JoyInfo.dev)
 					cv_usejoystick.value = JoyInfo.oldjoy = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
 				else if (atoi(cv_usejoystick.string) != JoyInfo2.oldjoy)
@@ -1014,6 +1031,17 @@ void I_GetEvent(void)
 					cv_usejoystick2.value = atoi(cv_usejoystick.string);
 				else // we tried...
 					cv_usejoystick2.value = 0;
+
+				// Was cv_usejoystick disabled in settings?
+				if (!strcmp(cv_usejoystick.string, "0"))
+					cv_usejoystick.value = 0;
+				else if (cv_usejoystick.value) // update the cvar ONLY if a device exists
+					CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
+
+				if (!strcmp(cv_usejoystick2.string, "0"))
+					cv_usejoystick2.value = 0;
+				else if (cv_usejoystick2.value) // update the cvar ONLY if a device exists
+					CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
 
 				CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);
 				CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index: %d\n", JoyInfo2.oldjoy);

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -981,12 +981,14 @@ void I_GetEvent(void)
 					// Was cv_usejoystick disabled in settings?
 					if (!strcmp(cv_usejoystick.string, "0") || !cv_usejoystick.value)
 						cv_usejoystick.value = 0;
-					else if (cv_usejoystick.value) // update the cvar ONLY if a device exists
+					else if (atoi(cv_usejoystick.string) <= I_NumJoys() // don't mess if we intentionally set higher than NumJoys
+						     && cv_usejoystick.value) // update the cvar ONLY if a device exists
 						CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
 
 					if (!strcmp(cv_usejoystick2.string, "0") || !cv_usejoystick2.value)
 						cv_usejoystick2.value = 0;
-					else if (cv_usejoystick2.value) // update the cvar ONLY if a device exists
+					else if (atoi(cv_usejoystick2.string) <= I_NumJoys() // don't mess if we intentionally set higher than NumJoys
+					         && cv_usejoystick2.value) // update the cvar ONLY if a device exists
 						CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
 
 					// Update all joysticks' init states
@@ -1044,12 +1046,14 @@ void I_GetEvent(void)
 				// Was cv_usejoystick disabled in settings?
 				if (!strcmp(cv_usejoystick.string, "0"))
 					cv_usejoystick.value = 0;
-				else if (cv_usejoystick.value) // update the cvar ONLY if a device exists
+				else if (atoi(cv_usejoystick.string) <= I_NumJoys() // don't mess if we intentionally set higher than NumJoys
+						 && cv_usejoystick.value) // update the cvar ONLY if a device exists
 					CV_SetValue(&cv_usejoystick, cv_usejoystick.value);
 
 				if (!strcmp(cv_usejoystick2.string, "0"))
 					cv_usejoystick2.value = 0;
-				else if (cv_usejoystick2.value) // update the cvar ONLY if a device exists
+				else if (atoi(cv_usejoystick2.string) <= I_NumJoys() // don't mess if we intentionally set higher than NumJoys
+						 && cv_usejoystick2.value) // update the cvar ONLY if a device exists
 					CV_SetValue(&cv_usejoystick2, cv_usejoystick2.value);
 
 				CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -936,7 +936,27 @@ void I_GetEvent(void)
 			case SDL_JOYDEVICEADDED:
 				CONS_Debug(DBG_GAMELOGIC, "Joystick device index %d added\n", evt.jdevice.which + 1);
 
-				// recount hotplugged joysticks
+				// Because SDL's device index is unstable, we're going to cheat here a bit:
+				// For the first joystick setting that is NOT active:
+				// Set cv_usejoystickX.value to the new device index (this does not change what is written to config.cfg)
+				// Set OTHERS' cv_usejoystickX.value to THEIR new device index, because it likely changed
+				if (!JoyInfo.dev || !SDL_JoystickGetAttached(JoyInfo.dev))
+				{
+					cv_usejoystick.value = evt.jdevice.which + 1;
+
+					if (JoyInfo2.dev)
+						cv_usejoystick2.value = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
+				}
+				else if (!JoyInfo2.dev || !SDL_JoystickGetAttached(JoyInfo2.dev))
+				{
+					cv_usejoystick2.value = evt.jdevice.which + 1;
+
+					if (JoyInfo.dev)
+						cv_usejoystick.value = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
+				}
+
+				// If an active joystick's index has changed, these will just
+				// change the corresponding JoyInfo.oldjoy
 				I_InitJoystick();
 				I_InitJoystick2();
 
@@ -959,6 +979,13 @@ void I_GetEvent(void)
 					CONS_Debug(DBG_GAMELOGIC, "Joystick2 removed, device index: %d\n", JoyInfo2.oldjoy);
 					I_ShutdownJoystick2();
 				}
+
+				// Update the device indexes, because they likely changed
+				if (JoyInfo.dev)
+					JoyInfo.oldjoy = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
+
+				if (JoyInfo2.dev)
+					JoyInfo2.oldjoy = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
 
 				CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);
 				CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index: %d\n", JoyInfo2.oldjoy);

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -940,19 +940,33 @@ void I_GetEvent(void)
 				// For the first joystick setting that is NOT active:
 				// Set cv_usejoystickX.value to the new device index (this does not change what is written to config.cfg)
 				// Set OTHERS' cv_usejoystickX.value to THEIR new device index, because it likely changed
+				// If device doesn't exist, switch cv_usejoystick back to default value (.string)
+				// BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
 				if (!JoyInfo.dev || !SDL_JoystickGetAttached(JoyInfo.dev))
 				{
 					cv_usejoystick.value = evt.jdevice.which + 1;
 
 					if (JoyInfo2.dev)
-						cv_usejoystick2.value = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
+						cv_usejoystick2.value = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
+					else if (atoi(cv_usejoystick2.string) != JoyInfo.oldjoy)
+						cv_usejoystick2.value = atoi(cv_usejoystick2.string);
+					else if (atoi(cv_usejoystick.string) != JoyInfo.oldjoy)
+						cv_usejoystick2.value = atoi(cv_usejoystick.string);
+					else // we tried...
+						cv_usejoystick2.value = 0;
 				}
 				else if (!JoyInfo2.dev || !SDL_JoystickGetAttached(JoyInfo2.dev))
 				{
 					cv_usejoystick2.value = evt.jdevice.which + 1;
 
 					if (JoyInfo.dev)
-						cv_usejoystick.value = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
+						cv_usejoystick.value = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
+					else if (atoi(cv_usejoystick.string) != JoyInfo2.oldjoy)
+						cv_usejoystick.value = atoi(cv_usejoystick.string);
+					else if (atoi(cv_usejoystick2.string) != JoyInfo2.oldjoy)
+						cv_usejoystick.value = atoi(cv_usejoystick2.string);
+					else // we tried...
+						cv_usejoystick.value = 0;
 				}
 
 				// If an active joystick's index has changed, these will just
@@ -981,11 +995,25 @@ void I_GetEvent(void)
 				}
 
 				// Update the device indexes, because they likely changed
+				// If device doesn't exist, switch cv_usejoystick back to default value (.string)
+				// BUT: If that default index is being occupied, use ANOTHER cv_usejoystick's default value!
 				if (JoyInfo.dev)
-					JoyInfo.oldjoy = SDL_JoystickInstanceID(JoyInfo.dev) + 1;
+					cv_usejoystick.value = JoyInfo.oldjoy = I_GetJoystickDeviceIndex(JoyInfo.dev) + 1;
+				else if (atoi(cv_usejoystick.string) != JoyInfo2.oldjoy)
+					cv_usejoystick.value = atoi(cv_usejoystick.string);
+				else if (atoi(cv_usejoystick2.string) != JoyInfo2.oldjoy)
+					cv_usejoystick.value = atoi(cv_usejoystick2.string);
+				else // we tried...
+					cv_usejoystick.value = 0;
 
 				if (JoyInfo2.dev)
-					JoyInfo2.oldjoy = SDL_JoystickInstanceID(JoyInfo2.dev) + 1;
+					cv_usejoystick2.value = JoyInfo2.oldjoy = I_GetJoystickDeviceIndex(JoyInfo2.dev) + 1;
+				else if (atoi(cv_usejoystick2.string) != JoyInfo.oldjoy)
+					cv_usejoystick2.value = atoi(cv_usejoystick2.string);
+				else if (atoi(cv_usejoystick.string) != JoyInfo.oldjoy)
+					cv_usejoystick2.value = atoi(cv_usejoystick.string);
+				else // we tried...
+					cv_usejoystick2.value = 0;
 
 				CONS_Debug(DBG_GAMELOGIC, "Joystick1 device index: %d\n", JoyInfo.oldjoy);
 				CONS_Debug(DBG_GAMELOGIC, "Joystick2 device index: %d\n", JoyInfo2.oldjoy);

--- a/src/sdl/sdlmain.h
+++ b/src/sdl/sdlmain.h
@@ -31,6 +31,9 @@ extern SDL_bool framebuffer;
 #define SDL2STUB() CONS_Printf("SDL2: stubbed: %s:%d\n", __func__, __LINE__)
 #endif
 
+// So m_menu knows whether to store cv_usejoystick value or string
+#define JOYSTICK_HOTPLUG
+
 /**	\brief	The JoyInfo_s struct
 
   info about joystick

--- a/src/sdl/sdlmain.h
+++ b/src/sdl/sdlmain.h
@@ -67,6 +67,10 @@ extern SDLJoyInfo_t JoyInfo;
 */
 extern SDLJoyInfo_t JoyInfo2;
 
+// So we can call this from i_video event loop
+void I_ShutdownJoystick(void);
+void I_ShutdownJoystick2(void);
+
 void I_GetConsoleEvents(void);
 
 void SDLforceUngrabMouse(void);

--- a/src/sdl/sdlmain.h
+++ b/src/sdl/sdlmain.h
@@ -71,6 +71,9 @@ extern SDLJoyInfo_t JoyInfo2;
 void I_ShutdownJoystick(void);
 void I_ShutdownJoystick2(void);
 
+// Cheat to get the device index for a joystick handle
+INT32 I_GetJoystickDeviceIndex(SDL_Joystick *dev);
+
 void I_GetConsoleEvents(void);
 
 void SDLforceUngrabMouse(void);


### PR DESCRIPTION
Before 2.2, SDL's joystick subsystem would be shut down before the game started. This meant that Gamepads could only be recognized at game startup, and unplugging and replugging a gamepad would not work. This simply ports joystick hotplugging from 2.2