### PR TITLE
Add Haiku build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,11 @@ if(${CMAKE_SYSTEM} MATCHES "Windows") ###set on Windows only
 	"Use SRB2's internal copies of required dependencies (SDL2, PNG, zlib, GME, OpenMPT).")
 endif()
 
+if(${CMAKE_SYSTEM} MATCHES "Haiku")
+	target_compile_definitions(SRB2SDL2 PRIVATE -DNOEXECINFO)
+	target_link_libraries(SRB2SDL2 PRIVATE network)
+endif()
+
 add_definitions(-DHAVE_BLUA)
 add_subdirectory(blua)
 


### PR DESCRIPTION
Minimum required code to get SRB2 Legacy to compile and run on Haiku using CMake. I'm not going to go through all the effort of getting all components working like I did with 2.2, though - only singleplayer has been tested and confirmed to work as expected.