### PR TITLE
Cache and reuse removed mobjs when spawning mobjs (Backport of MR !2200)

### DIFF
--- a/src/d_think.h
+++ b/src/d_think.h
@@ -49,6 +49,7 @@ typedef struct thinker_s
 	// killough 11/98: count of how many other objects reference
 	// this one using pointers. Used for garbage collection.
 	INT32 references;
+	boolean cachable;
 } thinker_t;
 
 #endif

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -65,6 +65,7 @@
 
 // both the head and tail of the thinker list
 extern thinker_t thinkercap;
+extern mobj_t *mobjcache;
 
 void P_InitThinkers(void);
 void P_AddThinker(thinker_t *thinker);

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -45,6 +45,7 @@ consvar_t cv_splats = {"splats", "On", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0
 actioncache_t actioncachehead;
 
 static mobj_t *overlaycap = NULL;
+mobj_t *mobjcache = NULL;
 
 void P_InitCachedActions(void)
 {
@@ -7641,7 +7642,17 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
 {
 	const mobjinfo_t *info = &mobjinfo[type];
 	state_t *st;
-	mobj_t *mobj = Z_Calloc(sizeof (*mobj), PU_LEVEL, NULL);
+	mobj_t *mobj;
+	if (mobjcache != NULL)
+	{
+		mobj = mobjcache;
+		mobjcache = mobjcache->hnext;
+		memset(mobj, 0, sizeof(*mobj));
+	}
+	else
+	{
+		mobj = Z_Calloc(sizeof (*mobj), PU_LEVEL, NULL);
+	}
 
 	// this is officially a mobj, declared as soon as possible.
 	mobj->thinker.function.acp1 = (actionf_p1)P_MobjThinker;
@@ -8026,7 +8037,9 @@ void P_RemoveMobj(mobj_t *mobj)
 			// Invalidate mobj_t data to cause crashes if accessed!
 			memset(mobj, 0xff, sizeof(mobj_t));
 #endif
-			Z_Free(mobj); // No refrences? Can be removed immediately! :D
+			// no references, dump it directly in the mobj cache
+			mobj->hnext = mobjcache;
+			mobjcache = mobj;
 		}
 		else
 		{ // Add thinker just to delay removing it until refrences are gone.

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -2831,6 +2831,8 @@ boolean P_SetupLevel(boolean skipprecip)
 	R_ClearLevelSplats();
 #endif
 
+	mobjcache = NULL;
+
 	P_InitThinkers();
 	P_InitCachedActions();
 

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -193,6 +193,8 @@ void P_AddThinker(thinker_t *thinker)
 	thinkercap.prev = thinker;
 
 	thinker->references = 0;    // killough 11/98: init reference counter to 0
+
+	thinker->cachable = (thinker->function.acp1 == (actionf_p1)P_MobjThinker);
 }
 
 //
@@ -227,7 +229,16 @@ void P_RemoveThinkerDelayed(void *pthinker)
 			 * thinker->prev->next = thinker->next */
 			(next->prev = currentthinker = thinker->prev)->next = next;
 		}
+	if (thinker->cachable == true)
+	{
+		// put cachable thinkers in the mobj cache, so we can avoid allocations
+		((mobj_t *)thinker)->hnext = mobjcache;
+		mobjcache = (mobj_t *)thinker;
+	}
+	else
+	{
 		Z_Free(thinker);
+	}
 	}
 }
 


### PR DESCRIPTION
Backport of [!2200](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2200) , basically makes mobj spawning faster by caching removed mobjs and reusing them when needed. 