### PR TITLE
Fix segfault when deleting first overlay in overlaycap

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -6110,6 +6110,13 @@ static void P_AddOverlay(mobj_t *thing)
 static void P_RemoveOverlay(mobj_t *thing)
 {
 	mobj_t *mo;
+	if (overlaycap == thing)
+	{
+		P_SetTarget(&overlaycap, thing->hnext);
+		P_SetTarget(&thing->hnext, NULL);
+		return;
+	}
+
 	for (mo = overlaycap; mo; mo = mo->hnext)
 		if (mo->hnext == thing)
 		{


### PR DESCRIPTION
Fixes an old bug that has been around for a long time, but has been fixed in 2.2. Can be triggered with a debug build by switching color after switching skin to Inazuma.

Upstream patch: https://git.do.srb2.org/STJr/SRB2/-/merge_requests/1963