### PR TITLE
Improve file search performance on Linux and FreeBSD 

### DIFF
--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -503,10 +503,20 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 
 		// okay, now we actually want searchpath to incorporate d_name
 		strcpy(&searchpath[searchpathindex[depthleft]],dent->d_name);
+#if defined(__linux__) || defined(__FreeBSD__)
+		if (dent->d_type == DT_UNKNOWN)
+			if (lstat(searchpath,&fsstat) == 0 && S_ISDIR(fsstat.st_mode))
+				dent->d_type = DT_DIR;
+
+		// Linux and FreeBSD has a special field for file type on dirent, so use that to speed up lookups.
+		// FIXME: should we also follow symlinks?
+		if (dent->d_type == DT_DIR && depthleft)
+#else
 
 		if (stat(searchpath,&fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
 			; // was the file (re)moved? can't stat it
 		else if (S_ISDIR(fsstat.st_mode) && depthleft)
+#endif
 		{
 			searchpathindex[--depthleft] = strlen(searchpath) + 1;
 			dirhandle[depthleft] = opendir(searchpath);


### PR DESCRIPTION
[From the original merge request page](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2198):
currently, SRB2 tries to look up files recursively when searching for game files. while this gives us a flexible system, it can become a performance issue during startup since a lot of files tend to get dumped in the game directory after a while (stuff like downloaded addons, logs, lua files, etc). this can cause startup and load times to increase over time as the amount of files increases, and can even even hit the point where it can take more than 5 seconds to start up!
the cause of these slow load times, though, is a call to stat for every file in the directory. this makes the kernel resolve and look up every file twice, which increases the amount of time it takes to search substantially. fortunately, though, the information we need is already available in dirent on both Linux and FreeBSD, on the d_type field. using that, we can avoid a call to stat for every file (assuming the filesystem supports it). something similar might be also possible to implement on Windows to give the same performance gain, but i don't have a Windows system to develop and test with. if anyone wanna try to add this for Windows, feel free to do so.