### PR TITLE
Switch to use new 2.1 master server

### DIFF
--- a/src/mserv.c
+++ b/src/mserv.c
@@ -205,7 +205,7 @@ static void MasterServer_OnChange(void);
 static void ServerName_OnChange(void);
 
 #define DEF_PORT "28900"
-consvar_t cv_masterserver = {"masterserver", "ms.srb2.org:"DEF_PORT, CV_SAVE, NULL, MasterServer_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_masterserver = {"masterserver", "ms.srb2classic.net:"DEF_PORT, CV_SAVE, NULL, MasterServer_OnChange, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_servername = {"servername", "SRB2 server", CV_SAVE|CV_CALL|CV_NOINIT, NULL, ServerName_OnChange, 0, NULL, NULL, 0, 0, NULL};
 
 INT16 ms_RoomId = -1;
@@ -813,6 +813,7 @@ const char *GetMasterServerIP(void)
 	if (strstr(cv_masterserver.string, "srb2.ssntails.org:28910")
 	 || strstr(cv_masterserver.string, "srb2.servegame.org:28910")
 	 || strstr(cv_masterserver.string, "srb2.servegame.org:28900")
+	 || strstr(cv_masterserver.string, "ms.srb2.org:28900")
 	   )
 	{
 		// replace it with the current default one


### PR DESCRIPTION
So I've gone through the effort of setting up a master server for 2.1, which SRB2 Legacy can use. I've done some local testing and it works just fine both in a test environment and when deployed in production, but so far, I haven't been able to do any large-scale testing because you can only do so much alone. So if you run into any issues, please report it either here or on the Codeberg repository below.

The full source code for the master server can be found here: https://codeberg.org/Hanicef/srb2ms-evo

**NOTE**: As for the domain name, I plan to fork 2.2 once the last version of it releases under the name SRB2 Classic, and since the master server is compatible with both versions, I didn't see a reason to buy 2 domains for the same software, so 2.1 will be using SRB2 Classic's domain. Also, the 2.2 master server is currently disabled as 2.3 hasn't been released yet, so using it for 2.2 is not possible yet.