### PR TITLE
Fix FreeBSD build

### DIFF
--- a/src/Makefile.d/nix.mk
+++ b/src/Makefile.d/nix.mk
@@ -27,5 +27,5 @@ endif
 # Tested by Steel, as of release 2.2.8.
 ifdef FREEBSD
 opts+=-I/usr/X11R6/include -DLINUX -DFREEBSD
-libs+=-L/usr/X11R6/lib -lipx -lkvm
+libs+=-L/usr/X11R6/lib -lkvm
 endif


### PR DESCRIPTION
Most likely a leftover from 2.1, since IPX is not really a thing anymore and SRB2 doesn't even use it.