### PR TITLE
CMake: Fix Debug builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,3 +201,19 @@ endif()
 if(NOT ${SRB2_SDL2_AVAILABLE} AND NOT ${SRB2_WIN32_AVAILABLE})
 	message(FATAL_ERROR "There are no targets available to build an SRB2 executable. :(")
 endif()
+
+# strip debug symbols into separate file when using gcc.
+# to be consistent with Makefile, don't generate for OS X.
+if((CMAKE_COMPILER_IS_GNUCC) AND NOT ("${CMAKE_SYSTEM_NAME}" MATCHES Darwin))
+	if((${CMAKE_BUILD_TYPE} MATCHES Debug) OR (${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo))
+		if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+			set(OBJCOPY_ONLY_KEEP_DEBUG "--only-keep-debug")
+		endif()
+		message(STATUS "Will make separate debug symbols in *.debug")
+		add_custom_command(TARGET SRB2SDL2 POST_BUILD
+			COMMAND ${OBJCOPY} ${OBJCOPY_ONLY_KEEP_DEBUG} $<TARGET_FILE:SRB2SDL2> $<TARGET_FILE:SRB2SDL2>.debug
+			COMMAND ${OBJCOPY} --strip-debug $<TARGET_FILE:SRB2SDL2>
+			COMMAND ${OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:SRB2SDL2>.debug $<TARGET_FILE:SRB2SDL2>
+		)
+	endif()
+endif()

--- a/src/sdl/CMakeLists.txt
+++ b/src/sdl/CMakeLists.txt
@@ -134,18 +134,6 @@ if(${SDL2_FOUND})
 		-DHAVE_SDL
 	)
 
-	## strip debug symbols into separate file when using gcc
-	if(CMAKE_COMPILER_IS_GNUCC)
-		if(${CMAKE_BUILD_TYPE} MATCHES Debug)
-			message(STATUS "Will make separate debug symbols in *.debug")
-			add_custom_command(TARGET SRB2SDL2 POST_BUILD
-				COMMAND ${OBJCOPY} --only-keep-debug $<TARGET_FILE:SRB2SDL2> $<TARGET_FILE:SRB2SDL2>.debug
-				COMMAND ${OBJCOPY} --strip-debug $<TARGET_FILE:SRB2SDL2>
-				COMMAND ${OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE_NAME:SRB2SDL2>.debug $<TARGET_FILE:SRB2SDL2>
-			)
-		endif()
-	endif()
-
 	#### Installation ####
 	if(${CMAKE_SYSTEM} MATCHES Darwin)
 		install(TARGETS SRB2SDL2
@@ -155,6 +143,15 @@ if(${SDL2_FOUND})
 		install(TARGETS SRB2SDL2 SRB2SDL2
 			RUNTIME DESTINATION .
 		)
+		if ((${CMAKE_BUILD_TYPE} MATCHES Debug) OR (${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo))
+			set(SRB2_DEBUG_INSTALL OFF CACHE BOOL "Insert *.debug file into the install directory or package.")
+			if (${SRB2_DEBUG_INSTALL})
+				install(FILES $<TARGET_FILE:SRB2SDL2>.debug
+					DESTINATION .
+					OPTIONAL
+				)
+			endif()
+		endif()
 	endif()
 
 	if(${CMAKE_SYSTEM} MATCHES Windows)


### PR DESCRIPTION
Debug builds fail with:
```
CMake Error at src/sdl/CMakeLists.txt:141 (add_custom_command):
  TARGET 'SRB2SDL2' was not created in this directory.
```

This is a partial backport of
a015be2a54d3 ("cmake: Build all deps and static link") and efba50c83c73 ("CMAKE: Add SRB2_DEBUG_INSTALL to toggle *.debug in install/package") that solves this issue.