### PR TITLE
Fix mouse button binding in menu

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2813,6 +2813,12 @@ void M_SetupNextMenu(menu_t *menudef)
 	}
 }
 
+// Guess I'll put this here, idk
+boolean M_MouseNeeded(void)
+{
+	return (currentMenu == &MessageDef && currentMenu->prevMenu == &OP_AllControlsDef);
+}
+
 //
 // M_Ticker
 //

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -170,6 +170,9 @@ typedef struct menu_s
 void M_SetupNextMenu(menu_t *menudef);
 void M_ClearMenus(boolean callexitmenufunc);
 
+// Maybe this goes here????? Who knows.
+boolean M_MouseNeeded(void);
+
 extern menu_t *currentMenu;
 
 extern menu_t MainDef;


### PR DESCRIPTION
It was impossible to bind the mouse buttons through the menu. In addition, this re-adds the ability to skip cutscenes without grabbing the cursor.

Fixes: 8e107b78537f ("Let the mouse move freely when a menu is open or game is paused (port of MR 617)")