### PR TITLE
Fix SDL_Mixer native MIDI

### DIFF
--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1875,6 +1875,11 @@ void GameMIDIMusic_OnChange(void)
 
 void MusicPref_OnChange(void)
 {
+	// Ensure sound is started.
+	// This gets called on startup, before Mix_OpenAudio has been called, marking native MIDI as broken.
+	if(!sound_started)
+		return;
+
 	if (M_CheckParm("-nomusic") || M_CheckParm("-noaudio") ||
 		M_CheckParm("-nomidimusic") || M_CheckParm("-nodigmusic"))
 		return;


### PR DESCRIPTION
SDL_Mixer's native MIDI was broken because the game tried to play audio before Mix_OpenAudio has been called. This resulted in the native MIDI backend being marked as broken, falling back to the next one.

Fix it by checking if sound has been initialised before trying to play anything on musicpref cvar change.

Fixes: 2544f548cda0 ("Add musicpref console variable (backport of MR !939)")