### PR TITLE
Fix keyboard input in menus registering in-game

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2390,7 +2390,7 @@ boolean M_Responder(event_t *ev)
 		// ignore ev_keydown events if the key maps to a character, since
 		// the ev_text event will follow immediately after in that case.
 		if (ev->type == ev_keydown && ch >= 32 && ch <= 127)
-			return false;
+			return true;
 		routine(ch);
 		return true;
 	}


### PR DESCRIPTION
Minor regression caused by native keyboard layout, where keypresses in menus would pass through the menu and be registered in-game, causing you to move around with WASD when typing your player name in player setup, for example.