### PR TITLE
Fix bad file descriptor error on master server socket

### DIFF
--- a/src/mserv.c
+++ b/src/mserv.c
@@ -382,6 +382,7 @@ static INT32 MS_Connect(const char *ip_addr, const char *str_port, INT32 async)
 
 	while (runp != NULL)
 	{
+		CloseConnection();
 		socket_fd = socket(runp->ai_family, runp->ai_socktype, runp->ai_protocol);
 		if (socket_fd != (SOCKET_TYPE)ERRSOCKET)
 		{


### PR DESCRIPTION
Fixes the issue mentioned in #27, where the master server socket would fail to connect due to the existing socket being in a bad state. It seemed to be caused by old sockets not being deallocated properly on a failed connection attempts, so it would just sit around in memory until the socket count would be exhausted.

I plan to overhaul the master server logic later to add IPv6 support as well as make it all background-threaded, so updates to the master server doesn't cause stuttering on a server with a high latency to the MS. This is just a lesser hack to fix the immediate problem with it.