### PR TITLE
Fix Haiku build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,11 +36,6 @@ if(${CMAKE_SYSTEM} MATCHES "Windows") ###set on Windows only
 	"Use SRB2's internal copies of required dependencies (SDL2, PNG, zlib, GME, OpenMPT).")
 endif()
 
-if(${CMAKE_SYSTEM} MATCHES "Haiku")
-	target_compile_definitions(SRB2SDL2 PRIVATE -DNOEXECINFO)
-	target_link_libraries(SRB2SDL2 PRIVATE network)
-endif()
-
 add_definitions(-DHAVE_BLUA)
 add_subdirectory(blua)
 

--- a/src/sdl/CMakeLists.txt
+++ b/src/sdl/CMakeLists.txt
@@ -41,7 +41,8 @@ if(${SRB2_CONFIG_USE_INTERNAL_LIBRARIES})
 		set(SDL2_LIBRARIES "-L${CMAKE_SOURCE_DIR}/libs/SDL2/i686-w64-mingw32/lib -lSDL2")
 	endif()
 else()
-	find_package(SDL2)
+	find_package(SDL2 CONFIG REQUIRED)
+	find_package(SDL2 REQUIRED)
 endif()
 
 if(${SDL2_FOUND})
@@ -114,6 +115,10 @@ if(${SDL2_FOUND})
 		target_compile_options(SRB2SDL2 PRIVATE
 			-U_WINDOWS
 		)
+	endif()
+
+	if(${CMAKE_SYSTEM} MATCHES "Haiku")
+		target_link_libraries(SRB2SDL2 PRIVATE network)
 	endif()
 
 	target_include_directories(SRB2SDL2 PRIVATE


### PR DESCRIPTION
Haiku CMake build refused to work on my system on the latest commit, and I managed to get it working after some tweaking. The problem is that Haiku has it's system stuff in unconventional places, so standard dependency resolution doesn't always work. This can be solved by adding a dependency using the `CONFIG` setting on the dependency, and another without it too, so it looks in standard directories.

This patch also makes `SDL2` a required dependency since without it, it obviously won't link correctly, so we really shouldn't allow it.