### PR TITLE
Fix potential segfault when rendering precipitation in OpenGL

### DIFF
--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -4826,7 +4826,7 @@ static inline void HWR_DrawPrecipitationSprite(gr_vissprite_t *spr)
 	GLPatch_t *gpatch; // sprite patch converted to hardware
 	FSurfaceInfo Surf;
 
-	if (!spr->mobj)
+	if (P_MobjWasRemoved(spr->mobj))
 		return;
 
 	if (!spr->mobj->subsector)


### PR DESCRIPTION
This fixes a potential segfault that can occur when OpenGL draws precipitation mobjs. In a nutshell, if a precip mobj is being referenced by another object, it's removal will be delayed to prevent references to it to become dangling, but since the object won't be `NULL` in that case, you can still access it, but it's data is not valid. This can trigger a segfault if it only does a `NULL` check before accessing child elements of the object, and the correct thing to do is to use `P_MobjWasRemoved` instead to make sure that the object is actually valid before it's being used.

This crash can happen in Subarashii in the hub map, shortly after the map has loaded in.