### PR TITLE
Fix various possible segfaults reported by ASan

### DIFF
--- a/src/g_input.c
+++ b/src/g_input.c
@@ -1056,7 +1056,7 @@ INT32 G_KeyStringtoNum(const char *keystr)
 {
 	UINT32 j;
 
-	if (!keystr[1] && keystr[0] > ' ' && keystr[0] <= 'z')
+	if (keystr[0] > ' ' && keystr[0] <= 'z' && !keystr[1])
 		return keystr[0];
 
 	if (!strncmp(keystr, "KEY", 3) && keystr[3] >= '0' && keystr[3] <= '9')

--- a/src/hardware/hw_cache.c
+++ b/src/hardware/hw_cache.c
@@ -274,7 +274,7 @@ static void HWR_ResizeBlock(INT32 originalwidth, INT32 originalheight,
 		min = blockwidth;
 	}
 
-	for (k = 2048, j = 0; k > max; j++)
+	for (k = 256, j = 0; k > max; j++)
 		k>>=1;
 	grInfo->smallLodLog2 = gr_lods[j];
 	grInfo->largeLodLog2 = gr_lods[j];

--- a/src/hardware/r_opengl/r_opengl.c
+++ b/src/hardware/r_opengl/r_opengl.c
@@ -2315,6 +2315,7 @@ EXPORT void HWRAPI(PostImgRedraw) (float points[SCREENVERTS][SCREENVERTS][2])
 
 	pglDisable(GL_DEPTH_TEST);
 	pglDisable(GL_BLEND);
+	pglDisableClientState(GL_TEXTURE_COORD_ARRAY);
 
 	// const float blackBack[16]
 
@@ -2324,6 +2325,8 @@ EXPORT void HWRAPI(PostImgRedraw) (float points[SCREENVERTS][SCREENVERTS][2])
 
 	pglVertexPointer(3, GL_FLOAT, 0, blackBack);
 	pglDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+	pglEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
 	for(x=0;x<SCREENVERTS-1;x++)
 	{


### PR DESCRIPTION
After KitsuWhooa reported to me that the game started to segfault on THZ2 on OpenGL, I went ahead and did an ASan run to see what I could find, and oh boy, was there a lot to be found. This patch has 3 fixes for potential segfaults:

* When OpenGL is being initialized, the logic that handles LOD had a smaller buffer than what was specified. As a result, it would write beyond the actual LOD buffer, potentially triggering a segfault.
* When the game loads in the settings, it was possible for it to segfault if only one of the keys were specified. This happened because missing arguments return an empty string, but the logic checked the NULL character did so before the first char, which would cause it to read beyond the buffer on an empty string and potentially segfault.
* On OpenGL, the texture coodinates weren't disabled when rendering post-processing effects, which resulted in it using an old pointer in `glTexCoordArray`. This could trigger segfaults due to use-after-free, as OpenGL doesn't copy the pointer when it loads the array.

There is guaranteed to be more of these - this is only what I've found so far.