### PR TITLE
Switch to use the extended server list queries

### DIFF
--- a/src/d_net.h
+++ b/src/d_net.h
@@ -59,5 +59,6 @@ void Net_ConnectionTimeout(INT32 node);
 void Net_AbortPacketType(UINT8 packettype);
 void Net_SendAcks(INT32 node);
 void Net_WaitAllAckReceived(UINT32 timeout);
+boolean Net_IsNodeIPv6(INT32 node);
 
 #endif

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6720,6 +6720,8 @@ static void M_DrawConnectMenu(void)
 			V_DrawSmallString(currentMenu->x+202, S_LINEY(i)+8, globalflags, "\x85" "Mod");
 		if (serverlist[slindex].info.cheatsenabled)
 			V_DrawSmallString(currentMenu->x+222, S_LINEY(i)+8, globalflags, "\x83" "Cheats");
+		if (Net_IsNodeIPv6(serverlist[slindex].node))
+			V_DrawSmallString(currentMenu->x+252, S_LINEY(i)+8, globalflags, "\x84" "IPv6");
 
 		V_DrawSmallString(currentMenu->x, S_LINEY(i)+8, globalflags,
 		                     va("Ping: %u", (UINT32)LONG(serverlist[slindex].info.time)));

--- a/src/mserv.c
+++ b/src/mserv.c
@@ -132,6 +132,7 @@
 #define SEND_VERSION_MSG        	214
 #define GET_BANNED_MSG          	215 // Someone's been baaaaaad!
 #define PING_SERVER_MSG         	216
+#define GET_EXT_SERVER_MSG      	217
 
 #define HEADER_SIZE (sizeof (INT32)*4)
 
@@ -423,7 +424,7 @@ const msg_server_t *GetShortServersList(INT32 room)
 		return NULL;
 	}
 
-	msg.type = GET_SHORT_SERVER_MSG;
+	msg.type = GET_EXT_SERVER_MSG;
 	msg.length = 0;
 	msg.room = room;
 	if (MS_Write(fd, &msg) < 0)

--- a/src/mserv.h
+++ b/src/mserv.h
@@ -32,7 +32,7 @@ typedef union
 typedef struct
 {
 	msg_header_t header;
-	char ip[16];
+	char ip[40];
 	char port[8];
 	char name[32];
 	INT32 room;


### PR DESCRIPTION
While IPv6 support is almost there, there is one glaring problem with fully implementing it that was only now discovered. The problem is that the buffer for IP addresses on the master server is only 16 bytes, which is not large enough to fit an IPv6 address. As a backwards-compatible workaround, I added a new message type named `GET_EXT_SERVER_MSG` which is the same as the old `GET_SHORT_SERVER_MSG`, but with a 40-byte large buffer for IP addresses instead, which is large enough to fit an IPv6 address. In addition to this, the old message type will no longer send IPv6-enabled servers anymore, as chances are the address won't fit the buffer.

This patch also finally implements the IPv6 tag on servers that has an IPv6 address, like 2.2 does, so you can now differentiate IPv4 servers from IPv6 ones.

Corresponding master server code can be found here: https://codeberg.org/Hanicef/srb2ms-evo/src/branch/master/legacy.go#L412-L432