### PR TITLE
Fix linking with valgrind

### DIFF
--- a/src/Makefile.d/features.mk
+++ b/src/Makefile.d/features.mk
@@ -55,6 +55,7 @@ endif
 # (Valgrind is a memory debugger.)
 ifdef VALGRIND
 VALGRIND_PKGCONFIG?=valgrind
+VALGRIND_LDFLAGS=
 $(eval $(call Use_pkg_config,VALGRIND))
 ZDEBUG=1
 opts+=-DHAVE_VALGRIND


### PR DESCRIPTION
Fixes the following issue when building with VALGRIND=1 by simply not linking against the libraries, like upstream.
```
Linking lsdl2srb2legacy.debug...
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/valgrind/libcoregrind-amd64-linux.a(libnolto_coregrind_amd64_linux_a-m_main.o): in function `_start':
(.text+0x0): multiple definition of `_start'; /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/Scrt1.o:(.text+0x0): first defined here
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/valgrind/libcoregrind-amd64-linux.a(libnolto_coregrind_amd64_linux_a-m_main.o): relocation R_X86_64_32S against symbol `vgPlain_interim_stack' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: failed to set dynamic section sizes: bad value
```