### PR TITLE
Fix use-after-free when loading addons after searching addons

### DIFF
--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -742,6 +742,10 @@ boolean preparefilemenu(boolean samedepth)
 		return false;
 	}
 
+	if (dirmenu != coredirmenu)
+		Z_Free(dirmenu);
+	dirmenu = NULL;
+
 	for (; sizecoredirmenu > 0; sizecoredirmenu--) // clear out existing items
 	{
 		Z_Free(coredirmenu[sizecoredirmenu-1]);


### PR DESCRIPTION
In the addons menu, if you search for an addon and then add it, the game could potentially crash once the addon has finished loading. The reason is due to a use-after-free in the addon list, where when an addon is added, the menu will be refreshed to mark the newly added addon as added, but since the search list wasn't properly cleared, it would use old references that had been deallocated in the search list, which could potentially crash.

This patch fixes this by clearing the search list when the addon list is being reloaded, so it will be refreshed anew upon adding an addon.