### PR TITLE
Fix IP resolution on Haiku

### DIFF
--- a/src/i_tcp.c
+++ b/src/i_tcp.c
@@ -1295,10 +1295,10 @@ static SINT8 SOCK_NetMakeNodewPort(const char *address, const char *port)
 	hints.ai_protocol = IPPROTO_UDP;
 
 	gaie = I_getaddrinfo(address, port, &hints, &ai);
-	if (gaie == 0)
-	{
-		newnode = getfreenode();
-	}
+	if (gaie != 0)
+		return -1;
+
+	newnode = getfreenode();
 	if (newnode == -1)
 	{
 		I_freeaddrinfo(ai);


### PR DESCRIPTION
Once again, Haiku's quirky network stack revealed a bug in SRB2. In this case, Haiku would crash if it fails to resolve an address, because if it failed to resolve it, it would return a non-zero status code, but in that case, SRB2 would still pass the address info data to `I_freeaddrinfo`, which is not allowed on Haiku and would then consequently crash.

This changes the logic so it just returns immediately upon a failure, since it's bound to return a failure anyway if `I_getaddrinfo` failed.