### PR TITLE
Fix segfault when rendering precip objects

### DIFF
--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -1103,7 +1103,6 @@ void OP_ObjectplaceMovement(player_t *player)
 	player->mo->old_y = player->mo->y;
 	player->mo->old_z = player->mo->z;
 
-
 	if (cmd->buttons & BT_JUMP)
 		player->mo->z += FRACUNIT*cv_speed.value;
 	else if (cmd->buttons & BT_USE)
@@ -1126,13 +1125,6 @@ void OP_ObjectplaceMovement(player_t *player)
 		player->mo->z = player->mo->ceilingz - player->mo->height;
 	if (player->mo->z < player->mo->floorz)
 		player->mo->z = player->mo->floorz;
-
-
-	player->mo->new_x = player->mo->x;
-	player->mo->new_y = player->mo->y;
-	player->mo->new_z = player->mo->z;
-
-
 
 	if (cv_opflags.value & MTF_OBJECTFLIP)
 		player->mo->eflags |= MFE_VERTICALFLIP;

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -265,7 +265,6 @@ typedef struct mobj_s
 
 	// Info for drawing: position.
 	fixed_t x, y, z;
-	fixed_t new_x, new_y, new_z;
 	fixed_t old_x, old_y, old_z; // position lerped between new and old, reset before tick
 	fixed_t old_x2, old_y2, old_z2;
 
@@ -388,13 +387,9 @@ typedef struct precipmobj_s
 	thinker_t thinker;
 
 	// Info for drawing: position.
-	fixed_t x, y, z; 
-	fixed_t new_x, new_y, new_z;
+	fixed_t x, y, z;
 	fixed_t old_x, old_y, old_z;
 	fixed_t old_x2, old_y2, old_z2;
-
-	
-
 
 	// More list: links in sector (if needed)
 	struct precipmobj_s *snext;

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -389,6 +389,7 @@ typedef struct precipmobj_s
 
 	// Info for drawing: position.
 	fixed_t x, y, z; 
+	fixed_t new_x, new_y, new_z;
 	fixed_t old_x, old_y, old_z;
 	fixed_t old_x2, old_y2, old_z2;
 


### PR DESCRIPTION
When rendering precip objects, the logic assumes that `precipmobj_t` and `mobj_t` have the same fields aligned in it. This allows it to use the same logic for both types, reducing redundant code (SRB2 actually following DRY principle, that's a first-timer), but of course, it breaks if any fields are misaligned.

In this case, it wasn't, as the new coordinate fields were missing on `precipmobj_t`, causing state updates during rendering to read the wrong field when casted to an `mobj_t` and consequently segfault the game. Adding these fields to `precipmobj_t` fixes the issue.