### PR TITLE
Fix server listing refusing to list servers on resolution failure

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -1733,7 +1733,7 @@ void CL_UpdateServerList(boolean internetsearch, INT32 room)
 				{
 					INT32 node = I_NetMakeNodewPort(server_list[i].ip, server_list[i].port);
 					if (node == -1)
-						break; // no more node free
+						continue; // no more node free, or resolution failure
 					SendAskInfo(node, true);
 					// Force close the connection so that servers can't eat
 					// up nodes forever if we never get a reply back from them


### PR DESCRIPTION
If an address from the MS fails to resolve, the engine would just bail, and not attempt to resolve any other addresses, resulting in an incomplete server list. This was discovered thanks to #53, as Haiku would crash is this case, which kinda revealed the problem.

Also, this is not the first time Haiku has revealed a bug in netcode - it made big revelations in 2.2 when porting it for the first time, so that's another reason to keep the port alive, even if nobody uses it (maybe consider a HaikuPorts package?).