### PR TITLE
CMake: Fix dedicated Debug builds

### DIFF
--- a/src/dedicated/CMakeLists.txt
+++ b/src/dedicated/CMakeLists.txt
@@ -62,18 +62,6 @@ target_compile_definitions(SRB2SDL2 PRIVATE
 	-DDEDICATED
 )
 
-## strip debug symbols into separate file when using gcc
-if(CMAKE_COMPILER_IS_GNUCC)
-	if(${CMAKE_BUILD_TYPE} MATCHES Debug)
-		message(STATUS "Will make separate debug symbols in *.debug")
-		add_custom_command(TARGET SRB2SDL2 POST_BUILD
-			COMMAND ${OBJCOPY} --only-keep-debug $<TARGET_FILE:SRB2SDL2> $<TARGET_FILE:SRB2SDL2>.debug
-			COMMAND ${OBJCOPY} --strip-debug $<TARGET_FILE:SRB2SDL2>
-			COMMAND ${OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE_NAME:SRB2SDL2>.debug $<TARGET_FILE:SRB2SDL2>
-		)
-	endif()
-endif()
-
 #### Installation ####
 if(${CMAKE_SYSTEM} MATCHES Darwin)
 	install(TARGETS SRB2SDL2
@@ -83,6 +71,15 @@ else()
 	install(TARGETS SRB2SDL2 SRB2SDL2
 		RUNTIME DESTINATION .
 	)
+	if ((${CMAKE_BUILD_TYPE} MATCHES Debug) OR (${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo))
+		set(SRB2_DEBUG_INSTALL OFF CACHE BOOL "Insert *.debug file into the install directory or package.")
+		if (${SRB2_DEBUG_INSTALL})
+			install(FILES $<TARGET_FILE:SRB2SDL2>.debug
+				DESTINATION .
+				OPTIONAL
+			)
+		endif()
+	endif()
 endif()
 
 # Mac bundle fixup


### PR DESCRIPTION
Similar to f84c5aae90a7 ("CMake: Fix Debug builds") but for dedicated server builds.