### PR TITLE
Fix segfault when rings are attracted

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2939,7 +2939,7 @@ retry:
 	{
 		// the move must have hit the middle, so stairstep
 stairstep:
-		if (!P_TryMove(mo, mo->x, mo->y + mo->momy, true)) //Allow things to drop off.
+		if (!P_MobjWasRemoved(mo) && !P_TryMove(mo, mo->x, mo->y + mo->momy, true)) //Allow things to drop off.
 			P_TryMove(mo, mo->x + mo->momx, mo->y, true);
 		return;
 	}

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -7091,6 +7091,8 @@ void P_MobjThinker(mobj_t *mobj)
 		case MT_BLUETEAMRING:
 			// No need to check water. Who cares?
 			P_RingThinker(mobj);
+			if (P_MobjWasRemoved(mobj))
+				return;
 			if (mobj->flags2 & MF2_NIGHTSPULL)
 				P_NightsItemChase(mobj);
 			else


### PR DESCRIPTION
Occurred on Sonic Adventure map pack, if rings are removed as they are being pulled, the game could potentially segfault as there are no checks that makes sure the mobj is still valid.