### PR TITLE
Fix MS registration after IPv6 listing was introduced

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -1711,7 +1711,7 @@ void CL_UpdateServerList(boolean internetsearch, INT32 room)
 
 	if (internetsearch)
 	{
-		const msg_server_t *server_list;
+		const msg_server_ext_t *server_list;
 		INT32 i = -1;
 		server_list = GetShortServersList(room);
 		if (server_list)

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -1711,7 +1711,7 @@ void CL_UpdateServerList(boolean internetsearch, INT32 room)
 
 	if (internetsearch)
 	{
-		const msg_server_ext_t *server_list;
+		const msg_ext_server_t *server_list;
 		INT32 i = -1;
 		server_list = GetShortServersList(room);
 		if (server_list)

--- a/src/mserv.c
+++ b/src/mserv.c
@@ -409,9 +409,9 @@ static INT32 MS_Connect(const char *ip_addr, const char *str_port, int flags)
 }
 
 #define NUM_LIST_SERVER MAXSERVERLIST
-const msg_server_t *GetShortServersList(INT32 room)
+const msg_server_ext_t *GetShortServersList(INT32 room)
 {
-	static msg_server_t server_list[NUM_LIST_SERVER+1]; // +1 for easy test
+	static msg_server_ext_t server_list[NUM_LIST_SERVER+1]; // +1 for easy test
 	msg_t msg;
 	INT32 i;
 

--- a/src/mserv.c
+++ b/src/mserv.c
@@ -409,9 +409,9 @@ static INT32 MS_Connect(const char *ip_addr, const char *str_port, int flags)
 }
 
 #define NUM_LIST_SERVER MAXSERVERLIST
-const msg_server_ext_t *GetShortServersList(INT32 room)
+const msg_ext_server_t *GetShortServersList(INT32 room)
 {
-	static msg_server_ext_t server_list[NUM_LIST_SERVER+1]; // +1 for easy test
+	static msg_ext_server_t server_list[NUM_LIST_SERVER+1]; // +1 for easy test
 	msg_t msg;
 	INT32 i;
 
@@ -441,7 +441,7 @@ const msg_server_ext_t *GetShortServersList(INT32 room)
 			CloseConnection(fd);
 			return server_list;
 		}
-		M_Memcpy(&server_list[i], msg.buffer, sizeof (msg_server_t));
+		M_Memcpy(&server_list[i], msg.buffer, sizeof (msg_ext_server_t));
 		server_list[i].header.buffer[0] = 1;
 	}
 	CloseConnection(fd);

--- a/src/mserv.h
+++ b/src/mserv.h
@@ -47,7 +47,7 @@ typedef struct
 	char name[32];
 	INT32 room;
 	char version[8]; // format is: x.yy.z (like 1.30.2 or 1.31)
-} ATTRPACK msg_server_ext_t;
+} ATTRPACK msg_ext_server_t;
 
 typedef struct
 {
@@ -93,7 +93,7 @@ void UnregisterServer(void);
 
 void MasterClient_Ticker(void);
 
-const msg_server_ext_t *GetShortServersList(INT32 room);
+const msg_ext_server_t *GetShortServersList(INT32 room);
 INT32 GetRoomsList(boolean hosting);
 #ifdef UPDATE_ALERT
 const char *GetMODVersion(void);

--- a/src/mserv.h
+++ b/src/mserv.h
@@ -32,12 +32,22 @@ typedef union
 typedef struct
 {
 	msg_header_t header;
-	char ip[40];
+	char ip[16];
 	char port[8];
 	char name[32];
 	INT32 room;
 	char version[8]; // format is: x.yy.z (like 1.30.2 or 1.31)
 } ATTRPACK msg_server_t;
+
+typedef struct
+{
+	msg_header_t header;
+	char ip[40];
+	char port[8];
+	char name[32];
+	INT32 room;
+	char version[8]; // format is: x.yy.z (like 1.30.2 or 1.31)
+} ATTRPACK msg_server_ext_t;
 
 typedef struct
 {
@@ -83,7 +93,7 @@ void UnregisterServer(void);
 
 void MasterClient_Ticker(void);
 
-const msg_server_t *GetShortServersList(INT32 room);
+const msg_server_ext_t *GetShortServersList(INT32 room);
 INT32 GetRoomsList(boolean hosting);
 #ifdef UPDATE_ALERT
 const char *GetMODVersion(void);


### PR DESCRIPTION
So, a big goof on my end: when IPv6 server listing was introduced to the MS, I didn't think of the fact that the buffer used for registering on the MS is the same as the one used for querying, so it ended up sending a larger packet than the MS was expecting, causing servers to fail to register. The MS actually ignores the host part and uses the IP of the source connection instead when registering to not make it too easy to spoof IP addresses, so it doesn't need to be expanded for IPv6.

This patch now splits these packet types into two different types, so everything should now be in working condition again.