### PR TITLE
Fix server crash when clients quit special stages

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2403,28 +2403,31 @@ static void CL_RemovePlayer(INT32 playernum, INT32 reason)
 	// the remaining players.
 	if (G_IsSpecialStage(gamemap))
 	{
-		INT32 i, count, increment, rings;
+		INT32 count;
 
-		for (i = 0, count = 0; i < MAXPLAYERS; i++)
+		for (INT32 i = 0, count = 0; i < MAXPLAYERS; i++)
 		{
 			if (playeringame[i])
 				count++;
 		}
 
 		count--;
-		rings = players[playernum].health - 1;
-		increment = rings/count;
-
-		for (i = 0; i < MAXPLAYERS; i++)
+		if(count > 0)
 		{
-			if (playeringame[i] && i != playernum)
-			{
-				if (rings < increment)
-					P_GivePlayerRings(&players[i], rings);
-				else
-					P_GivePlayerRings(&players[i], increment);
+			INT32 rings = players[playernum].health - 1;
+			INT32 increment = rings/count;
 
-				rings -= increment;
+			for (INT32 i = 0; i < MAXPLAYERS; i++)
+			{
+				if (playeringame[i] && i != playernum)
+				{
+					if (rings < increment)
+						P_GivePlayerRings(&players[i], rings);
+					else
+						P_GivePlayerRings(&players[i], increment);
+
+					rings -= increment;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When the last player quits the special stage, count ends up being 0, resulting in a division by zero and a SIGFPE, killing the server.

Simply check that count is > 0 before trying to divide. No point in trying to distribute rings when there are no players left.