### PR TITLE
Fix memory leak caused by word wrapping

### DIFF
--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1384,7 +1384,7 @@ static void HU_drawMiniChat(void)
 
 	for (; i>0; i--)
 	{
-		const char *msg = CHAT_WordWrap(x+2, boxw-(charwidth*2), V_SNAPTOBOTTOM|V_SNAPTOLEFT|V_ALLOWLOWERCASE, chat_mini[i-1]);
+		char *msg = CHAT_WordWrap(x+2, boxw-(charwidth*2), V_SNAPTOBOTTOM|V_SNAPTOLEFT|V_ALLOWLOWERCASE, chat_mini[i-1]);
 		size_t j = 0;
 		INT32 linescount = 0;
 
@@ -1426,6 +1426,7 @@ static void HU_drawMiniChat(void)
 		dy = 0;
 		dx = 0;
 		msglines += linescount+1;
+		Z_Free(msg);
 	}
 
 	y = chaty - charheight*(msglines+1);
@@ -1449,7 +1450,7 @@ static void HU_drawMiniChat(void)
 		INT32 timer = ((cv_chattime.value*TICRATE)-chat_timers[i]) - cv_chattime.value*TICRATE+9; // see below...
 		INT32 transflag = (timer >= 0 && timer <= 9) ? (timer*V_10TRANS) : 0; // you can make bad jokes out of this one.
 		size_t j = 0;
-		const char *msg = CHAT_WordWrap(x+2, boxw-(charwidth*2), V_SNAPTOBOTTOM|V_SNAPTOLEFT|V_ALLOWLOWERCASE, chat_mini[i]); // get the current message, and word wrap it.
+		char *msg = CHAT_WordWrap(x+2, boxw-(charwidth*2), V_SNAPTOBOTTOM|V_SNAPTOLEFT|V_ALLOWLOWERCASE, chat_mini[i]); // get the current message, and word wrap it.
 		UINT8 *colormap = NULL;
 
 		while(msg[j]) // iterate through msg
@@ -1495,6 +1496,7 @@ static void HU_drawMiniChat(void)
 		}
 		dy += charheight;
 		dx = 0;
+		Z_Free(msg);
 	}
 
 	// decrement addy and make that shit smooth:

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4775,12 +4775,15 @@ static void M_DrawChecklist(void)
 
 	for (i = 0; i < MAXUNLOCKABLES; i++)
 	{
+		char *s;
 		if (unlockables[i].name[0] == 0 || unlockables[i].nochecklist
 		|| !unlockables[i].conditionset || unlockables[i].conditionset > MAXCONDITIONSETS)
 			continue;
 
+		s = V_WordWrap(160, 292, 0, unlockables[i].objective);
 		V_DrawString(8, 8+(24*j), V_RETURN8, unlockables[i].name);
-		V_DrawString(160, 8+(24*j), V_RETURN8, V_WordWrap(160, 292, 0, unlockables[i].objective));
+		V_DrawString(160, 8+(24*j), V_RETURN8, s);
+		Z_Free(s);
 
 		if (unlockables[i].unlocked)
 			V_DrawString(308, 8+(24*j), V_YELLOWMAP, "Y");
@@ -4807,7 +4810,7 @@ static void M_DrawEmblemHints(void)
 	INT32 i, j = 0;
 	UINT32 collected = 0;
 	emblem_t *emblem;
-	const char *hint;
+	char *hint;
 
 	for (i = 0; i < numemblems; i++)
 	{
@@ -4833,6 +4836,7 @@ static void M_DrawEmblemHints(void)
 			hint = M_GetText("No hints available.");
 		hint = V_WordWrap(40, BASEVIDWIDTH-12, 0, hint);
 		V_DrawString(40, 8+(28*j), V_RETURN8|V_ALLOWLOWERCASE|collected, hint);
+		Z_Free(hint);
 
 		if (++j >= NUMHINTS)
 			break;
@@ -6637,7 +6641,7 @@ static INT32 menuRoomIndex = 0;
 
 static void M_DrawRoomMenu(void)
 {
-	const char *rmotd;
+	char *rmotd;
 
 	// use generic drawer for cursor, items and title
 	M_DrawGenericMenu();
@@ -6653,6 +6657,7 @@ static void M_DrawRoomMenu(void)
 
 	rmotd = V_WordWrap(0, 20*8, 0, rmotd);
 	V_DrawString(144+8, 32, V_ALLOWLOWERCASE|V_RETURN8, rmotd);
+	Z_Free(rmotd);
 }
 
 static void M_DrawConnectMenu(void)


### PR DESCRIPTION
`CHAT_WordWrap` and `V_WordWrap` both return a newly allocated string from it's input, but in numerous places where we call those functions, we don't deallocate the memory afterwards. This caused serious memory leaks, where the memory usage could go up to 3GB over just about 15 minutes when playing multiplayer. This patch properly deallocates the strings afterwards to fix the leaks.