### PR TITLE
Put saves in a separate folder

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1068,8 +1068,10 @@ void D_SRB2Main(void)
 		CONS_Printf(M_GetText("Development mode ON.\n"));
 
 	// default savegame
-	strcpy(savegamename, SAVEGAMENAME"%u.ssg");
-
+	if(M_CheckParm("-savedir") && M_IsNextParm())
+	{
+		snprintf(savefolder, sizeof(savefolder) - 1, "%s/", M_GetNextParm());
+	}
 	{
 		const char *userhome = D_Home(); //Alam: path to home
 
@@ -1100,8 +1102,6 @@ void D_SRB2Main(void)
 			else
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, srb2home);
 
-			// can't use sprintf since there is %u in savegamename
-			strcatbf(savegamename, srb2home, PATHSEP);
 
 #else
 			snprintf(srb2home, sizeof srb2home, "%s", userhome);
@@ -1110,13 +1110,11 @@ void D_SRB2Main(void)
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP "d"CONFIGFILENAME, userhome);
 			else
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, userhome);
-
-			// can't use sprintf since there is %u in savegamename
-			strcatbf(savegamename, userhome, PATHSEP);
 #endif
 		}
 
 		configfile[sizeof configfile - 1] = '\0';
+		P_SetSaveGameName("gamedata", SAVEGAMENAME);
 
 #ifdef _arch_dreamcast
 	strcpy(downloaddir, "/ram"); // the dreamcast's TMP

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -142,7 +142,7 @@ boolean advancedemo;
 INT32 debugload = 0;
 #endif
 
-char savegamename[256];
+char savegamename[512];
 
 #ifdef _arch_dreamcast
 char srb2home[256] = "/cd";

--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -33,6 +33,7 @@
 #include "lua_script.h"
 #include "lua_hook.h"
 #include "d_clisrv.h"
+#include "p_saveg.h"
 
 #include "m_cond.h"
 
@@ -3095,24 +3096,22 @@ static void readmaincfg(MYFILE *f)
 
 				G_SaveGameData();
 				DEH_WriteUndoline(word, gamedatafilename, UNDO_NONE);
-				strlcpy(gamedatafilename, word2, sizeof (gamedatafilename));
-				strlwr(gamedatafilename);
 				savemoddata = true;
 
 				// Also save a time attack folder
 
-				filenamelen = strlen(gamedatafilename);  // Strip off the extension
+				filenamelen = strlen(word2);  // Strip off the extension
 				if (filenamelen >= 4)
 					filenamelen -= 4;
 				if (filenamelen >= sizeof(timeattackfolder))
 					filenamelen = sizeof(timeattackfolder)-1;
-				strncpy(timeattackfolder, gamedatafilename, filenamelen);
-				timeattackfolder[min(filenamelen, sizeof (timeattackfolder) - 1)] = '\0';
+				char tmpfilename[256];
+				strncpy(tmpfilename, word2, filenamelen);
+				tmpfilename[min(filenamelen, sizeof (timeattackfolder) - 1)] = '\0';
+				strlwr(tmpfilename);
+				strncpy(timeattackfolder, tmpfilename, sizeof(timeattackfolder) - 1);
 
-				strcpy(savegamename, timeattackfolder);
-				strlcat(savegamename, "%u.ssg", sizeof(savegamename));
-				// can't use sprintf since there is %u in savegamename
-				strcatbf(savegamename, srb2home, PATHSEP);
+				P_SetSaveGameName(tmpfilename, tmpfilename);
 
 				gamedataadded = true;
 			}

--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -3105,11 +3105,11 @@ static void readmaincfg(MYFILE *f)
 					filenamelen -= 4;
 				if (filenamelen >= sizeof(timeattackfolder))
 					filenamelen = sizeof(timeattackfolder)-1;
-				char tmpfilename[256];
+				char tmpfilename[sizeof(timeattackfolder)];
 				strncpy(tmpfilename, word2, filenamelen);
 				tmpfilename[min(filenamelen, sizeof (timeattackfolder) - 1)] = '\0';
 				strlwr(tmpfilename);
-				strncpy(timeattackfolder, tmpfilename, sizeof(timeattackfolder) - 1);
+				strncpy(timeattackfolder, tmpfilename, sizeof(timeattackfolder));
 
 				P_SetSaveGameName(tmpfilename, tmpfilename);
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -381,7 +381,7 @@ void CONS_Debug(INT32 debugflags, const char *fmt, ...) FUNCDEBUG;
 
 // Things that used to be in dstrings.h
 #define SAVEGAMENAME "srb2sav"
-extern char savegamename[256];
+extern char savegamename[512];
 
 // m_misc.h
 #ifdef GETTEXT

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -66,6 +66,7 @@ JoyType_t Joystick2;
 
 char gamedatafilename[64] = "gamedata.dat";
 char timeattackfolder[64] = "main";
+char savefolder[64] = "save";
 char customversionstring[32] = "\0";
 
 static void G_DoCompleted(void);
@@ -3513,7 +3514,7 @@ void G_LoadGame(UINT32 slot, INT16 mapoverride)
 {
 	size_t length;
 	char vcheck[VERSIONSIZE];
-	char savename[255];
+	char savename[260];
 
 	// memset savedata to all 0, fixes calling perfectly valid saves corrupt because of bots
 	memset(&savedata, 0, sizeof(savedata));
@@ -3600,7 +3601,7 @@ void G_LoadGame(UINT32 slot, INT16 mapoverride)
 void G_SaveGame(UINT32 savegameslot)
 {
 	boolean saved;
-	char savename[256] = "";
+	char savename[260] = "";
 	const char *backup;
 
 	sprintf(savename, savegamename, savegameslot);

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -46,7 +46,7 @@
 #include "lua_hook.h"
 #include "b_bot.h"
 #include "m_cond.h" // condition sets
-#include "md5.h" // demo checksums 
+#include "md5.h" // demo checksums
 #include "r_fps.h" // Uncapped
 
 
@@ -66,7 +66,7 @@ JoyType_t Joystick2;
 
 char gamedatafilename[512] = "gamedata.dat";
 char timeattackfolder[64] = "main";
-char savefolder[64] = "save";
+char savefolder[64] = "saves";
 char customversionstring[32] = "\0";
 
 static void G_DoCompleted(void);
@@ -5840,4 +5840,3 @@ INT32 G_TicsToMilliseconds(tic_t tics)
 {
 	return (INT32)((tics%TICRATE) * (1000.00f/TICRATE));
 }
-

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -64,7 +64,7 @@ JoyType_t Joystick2;
 // 1024 bytes is plenty for a savegame
 #define SAVEGAMESIZE (1024)
 
-char gamedatafilename[64] = "gamedata.dat";
+char gamedatafilename[512] = "gamedata.dat";
 char timeattackfolder[64] = "main";
 char savefolder[64] = "save";
 char customversionstring[32] = "\0";

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -20,6 +20,7 @@
 
 extern char gamedatafilename[64];
 extern char timeattackfolder[64];
+extern char savefolder[64];
 extern char customversionstring[32];
 #define GAMEDATASIZE (4*8192)
 

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -18,7 +18,7 @@
 #include "doomstat.h"
 #include "d_event.h"
 
-extern char gamedatafilename[64];
+extern char gamedatafilename[512];
 extern char timeattackfolder[64];
 extern char savefolder[64];
 extern char customversionstring[32];

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -3331,6 +3331,28 @@ static inline boolean P_NetUnArchiveMisc(void)
 	return true;
 }
 
+void P_SetSaveGameName(const char* gamedataPrefix, const char* savedataPrefix)
+{
+	char buffer[512];
+	snprintf(buffer, sizeof(buffer) -1, "%s/%s", srb2home, savefolder);
+	I_mkdir(buffer, 0755);
+	snprintf(gamedatafilename, sizeof(gamedatafilename) - 1, "%s/%s/%s.dat", srb2home, savefolder, gamedataPrefix);
+	snprintf(savegamename, sizeof(savegamename) - 1, "%s/%s/%s%%u.ssg", srb2home, savefolder, savedataPrefix);
+
+	CONS_Printf("%s\n%s\n%s\n", gamedatafilename, timeattackfolder, savegamename);
+
+	// Check if we have a gamedata to copy it from root
+	FILE* f = fopen(gamedatafilename, "rb");
+	if(!f)
+	{
+		//TODO: copy old files
+	}
+	else
+	{
+		fclose(f);
+	}
+}
+
 void P_SaveGame(void)
 {
 	P_ArchiveMisc();

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -34,6 +34,7 @@
 #include "p_slopes.h"
 #endif
 #include "m_menu.h"
+#include "i_system.h"
 
 savedata_t savedata;
 UINT8 *save_p;
@@ -3346,7 +3347,6 @@ void P_SetSaveGameName(const char* gamedataPrefix, const char* savedataPrefix)
 	FILE* f = fopen(gamedatafilename, "rb");
 	if(!f)
 	{
-		char dataBuffer[GAMEDATASIZE];
 		char buffer2[512];
 		snprintf(buffer, sizeof(buffer) - 1, "%s/%s.dat", srb2home, gamedataPrefix);
 

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -33,6 +33,7 @@
 #ifdef ESLOPE
 #include "p_slopes.h"
 #endif
+#include "m_menu.h"
 
 savedata_t savedata;
 UINT8 *save_p;
@@ -3341,11 +3342,34 @@ void P_SetSaveGameName(const char* gamedataPrefix, const char* savedataPrefix)
 
 	CONS_Printf("%s\n%s\n%s\n", gamedatafilename, timeattackfolder, savegamename);
 
-	// Check if we have a gamedata to copy it from root
+	// Attempt to copy files from root if we don't have a gamedata
 	FILE* f = fopen(gamedatafilename, "rb");
 	if(!f)
 	{
-		//TODO: copy old files
+		char dataBuffer[GAMEDATASIZE];
+		char buffer2[512];
+		snprintf(buffer, sizeof(buffer) - 1, "%s/%s.dat", srb2home, gamedataPrefix);
+
+		f = fopen(buffer, "rb");
+		if(f)
+		{
+			fclose(f);
+			rename(buffer, gamedatafilename);
+		}
+		
+
+		// Now repeat for saves
+		for(int slot = 0; slot < (MAXSAVEGAMES - 1); slot++)
+		{
+			snprintf(buffer, sizeof(buffer) - 1, "%s/%s%u.ssg", srb2home, savedataPrefix, slot);
+			f = fopen(buffer, "rb");
+			if(f)
+			{
+				snprintf(buffer2, sizeof(buffer2) - 1, "%s/%s/%s%u.ssg", srb2home, savefolder, savedataPrefix, slot);
+				fclose(f);
+				rename(buffer, buffer2);
+			}
+		}
 	}
 	else
 	{

--- a/src/p_saveg.h
+++ b/src/p_saveg.h
@@ -20,7 +20,7 @@
 
 // Persistent storage/archiving.
 // These are the load / save game routines.
-
+void P_SetSaveGameName(const char* gamedataPrefix, const char* savedataPrefix);
 void P_SaveGame(void);
 void P_SaveNetGame(void);
 boolean P_LoadGame(INT16 mapoverride);


### PR DESCRIPTION
The SRB2 directory can get quite messy and savefiles participate in that.

This PR put saves in a separate folder. This folder can be specified with the `-savedir` command-line parameter and is by default "save".