### PR TITLE
Remove maxsend limits

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2946,7 +2946,7 @@ consvar_t cv_resynchattempts = {"resynchattempts", "10", 0, resynchattempts_cons
 consvar_t cv_blamecfail = {"blamecfail", "Off", 0, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL	};
 
 // max file size to send to a player (in kilobytes)
-static CV_PossibleValue_t maxsend_cons_t[] = {{0, "MIN"}, {51200, "MAX"}, {0, NULL}};
+static CV_PossibleValue_t maxsend_cons_t[] = {{-1, "MIN"}, {999999999, "MAX"}, {0, NULL}};
 consvar_t cv_maxsend = {"maxsend", "4096", CV_SAVE, maxsend_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_noticedownload = {"noticedownload", "Off", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
 

--- a/src/d_netfil.c
+++ b/src/d_netfil.c
@@ -126,7 +126,7 @@ UINT8 *PutFileNeeded(void)
 		// Store in the upper four bits
 		if (!cv_downloading.value)
 			filestatus += (2 << 4); // Won't send
-		else if ((wadfiles[i]->filesize <= (UINT32)cv_maxsend.value * 1024))
+		else if (cv_maxsend.value == -1 || (wadfiles[i]->filesize <= (UINT32)cv_maxsend.value * 1024))
 			filestatus += (1 << 4); // Will send if requested
 		// else
 			// filestatus += (0 << 4); -- Won't send, too big
@@ -529,7 +529,7 @@ static boolean SV_SendFile(INT32 node, const char *filename, UINT8 fileid)
 	}
 
 	// Handle huge file requests (i.e. bigger than cv_maxsend.value KB)
-	if (wadfiles[i]->filesize > (UINT32)cv_maxsend.value * 1024)
+	if (cv_maxsend.value != -1 && wadfiles[i]->filesize > (UINT32)cv_maxsend.value * 1024)
 	{
 		// Too big
 		// Don't inform client (client sucks, man)


### PR DESCRIPTION
This patch allows increasing `maxsend` to any number as you like, or remove the limit entirely by setting it to -1. This is invaluable for hosters, since limits to download sizes tend to be problematic when picking addons and can even render some addons not viable when doing serious hosting. By removing this limit, hosters won't need to worry about this, and focus can instead be put on curating a good set of addons for a server.