### PR TITLE
Fix emeralds spinning abnormally fast on evaluation screen

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -1314,6 +1314,7 @@ void F_StartGameEvaluation(void)
 	CON_ToggleOff();
 
 	finalecount = 0;
+	eemeralds_start = I_GetTime();
 }
 
 void F_GameEvaluationDrawer(void)
@@ -1332,8 +1333,7 @@ void F_GameEvaluationDrawer(void)
 	else
 		V_DrawString(124, 16, 0, "TRY AGAIN!");
 
-	eemeralds_start++;
-	eemeralds_cur = eemeralds_start;
+	eemeralds_cur = (I_GetTime() - eemeralds_start) % 360;
 
 	for (i = 0; i < 7; ++i)
 	{
@@ -1349,8 +1349,6 @@ void F_GameEvaluationDrawer(void)
 
 		eemeralds_cur += INTERVAL;
 	}
-	if (eemeralds_start >= 360)
-		eemeralds_start -= 360;
 
 	if (finalecount == 5*TICRATE)
 	{


### PR DESCRIPTION
On the game evaluation screen, after the credits, the emerald rotation logic weren't properly handling uncapped, so running at any framerate higher than 35 would cause it to spin faster than intended. At very high framerates (+500 fps), the emeralds would spin so fast that it would be impossible to tell which emeralds were missing. This patch fixes this by measuring time using `I_GetTime` instead, which causes it to position itself according to ticrate instead. While this is not the best solution, since it actually locks the emeralds to the ticrate, it at least solves the problem for the next version.