### PR TITLE
Fix emerald finder sound getting louder on higher framerates

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -652,6 +652,12 @@ void D_SRB2Loop(void)
 
 				doDisplay = true;
 			}
+
+			renderisnewtic = true;
+		}
+		else
+		{
+			renderisnewtic = false;
 		}
 
 		if (interp)

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -75,6 +75,7 @@ player_t *viewplayer;
 
 fixed_t rendertimefrac;
 fixed_t renderdeltatics;
+boolean renderisnewtic;
 
 
 // PORTALS!

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -33,6 +33,8 @@ extern size_t validcount, linecount, loopcount, framecount;
 extern fixed_t rendertimefrac;
 // Evaluated delta tics for this frame (how many tics since the last frame)
 extern fixed_t renderdeltatics;
+// The current render is a new logical tic
+extern boolean renderisnewtic;
 
 
 

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -2023,7 +2023,7 @@ static void ST_doHuntIconsAndSound(void)
 			interval = newinterval;
 	}
 
-	if (!(P_AutoPause() || paused) && interval > 0 && leveltime && leveltime % interval == 0)
+	if (!(P_AutoPause() || paused) && interval > 0 && leveltime && leveltime % interval == 0 && renderisnewtic)
 		S_StartSound(NULL, sfx_emfind);
 }
 
@@ -2083,7 +2083,7 @@ static void ST_doItemFinderIconsAndSound(void)
 		}
 	}
 
-	if (!(P_AutoPause() || paused) && interval > 0 && leveltime && leveltime % interval == 0)
+	if (!(P_AutoPause() || paused) && interval > 0 && leveltime && leveltime % interval == 0 && renderisnewtic)
 		S_StartSound(NULL, sfx_emfind);
 }
 


### PR DESCRIPTION
When running at higher framerates, the emerald finder sound was running alongside HUD logic, and as a result, wasn't capped to the 35 ticrate. This caused the sound to play repeatedly at once, which caused it to be louder than intended, with no limits to the amount of times it could play. On very high framerates, this sound could overlap so many times that it became ear-shatteringly loud.

To fix this, a new variable, `renderisnewtic`, is introduced that is set to true for the first frame in a tic. This allows us to prevent the sound from playing twice if a new tic hasn't started, causing it to only play once per tic as intended.