### PR TITLE
Fix console input via command prompt being uppercase on Windows

### DIFF
--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -479,7 +479,7 @@ static void Impl_HandleKeyboardConsoleEvent(KEY_EVENT_RECORD evt, HANDLE co)
 				entering_con_command = false;
 				/* FALLTHRU */
 			default:
-				event.data1 = MapVirtualKey(evt.wVirtualKeyCode,2); // convert in to char
+				event.data1 = evt.uChar.AsciiChar;
 		}
 		if (co != INVALID_HANDLE_VALUE && GetFileType(co) == FILE_TYPE_CHAR && GetConsoleMode(co, &t))
 		{

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -554,7 +554,7 @@ static void Impl_HandleKeyboardConsoleEvent(KEY_EVENT_RECORD evt, HANDLE co)
 				entering_con_command = false;
 				/* FALLTHRU */
 			default:
-				event.data1 = MapVirtualKey(evt.wVirtualKeyCode,2); // convert in to char
+				event.data1 = evt.uChar.AsciiChar;
 		}
 		if (co != INVALID_HANDLE_VALUE && GetFileType(co) == FILE_TYPE_CHAR && GetConsoleMode(co, &t))
 		{


### PR DESCRIPTION
This fixes a bug in the console input on Windows that forced the console input to be uppercased when inputted via the command prompt, which is normally the case for dedicated servers. The issue is that `MapVirtualKey` is meant to be used for key mapping and thus ignores modifier keys and forces uppercase - for actual keyboard input, `uChar.AsciiChar` is meant to be used (and `uChar.UnicodeChar`, but right now SRB2 doesn't support Unicode, so we can't use that yet).