### PR TITLE
Fix GIF recording only saving the first frame with no region optimiza…

### DIFF
--- a/src/m_anigif.c
+++ b/src/m_anigif.c
@@ -520,18 +520,15 @@ static void GIF_framewrite(void)
 		blitw = vid.width;
 		blith = vid.height;
 
-		if (gif_frames == 0)
-		{
-			if (rendermode == render_soft)
-				I_ReadScreen(movie_screen);
+		if (rendermode == render_soft)
+			I_ReadScreen(movie_screen);
 #ifdef HWRENDER
-			else if (rendermode == render_opengl)
-			{
-				hwrconvert();
-				VID_BlitLinearScreen(screens[2], screens[0], vid.width*vid.bpp, vid.height, vid.width*vid.bpp, vid.rowbytes);
-			}
-#endif
+		else if (rendermode == render_opengl)
+		{
+			hwrconvert();
+			VID_BlitLinearScreen(screens[2], screens[0], vid.width*vid.bpp, vid.height, vid.width*vid.bpp, vid.rowbytes);
 		}
+#endif
 		movie_screen = screens[0];
 	}
 


### PR DESCRIPTION
When region optimization is on, there is a check that makes sure it always renders the first frame in it's entirety, but when you turn it off, it still checks if it's on the first frame, and consequently doesn't render anything at all afterwards. This patch removes that problematic check, since the first frame check already exists in the outer if-statement when region optimization is on.

Fixes #81 