### PR TITLE
Fix various memory leaks

### DIFF
--- a/src/hardware/hw_cache.c
+++ b/src/hardware/hw_cache.c
@@ -430,7 +430,13 @@ void HWR_FreeTextureCache(void)
 	// now the heap don't have any 'user' pointing to our
 	// texturecache info, we can free it
 	if (gr_textures)
+	{
+		for (i = 0; i < gr_numtextures; i++)
+		{
+			Z_Free(gr_textures[i].mipmap.grInfo.data);
+		}
 		free(gr_textures);
+	}
 	gr_textures = NULL;
 	gr_numtextures = 0;
 }

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -5142,6 +5142,8 @@ static void M_DrawLoadGameData(void)
 	{
 		UINT8 *colormap = R_GetTranslationColormap(savegameinfo[saveSlotSelected].skinnum, savegameinfo[saveSlotSelected].skincolor, 0);
 		V_DrawMappedPatch(SP_LoadDef.x,144+8,0,W_CachePatchName(skins[savegameinfo[saveSlotSelected].skinnum].face, PU_CACHE), colormap);
+
+		Z_Free(colormap);
 	}
 
 	V_DrawString(ecks + 12, 152, 0, savegameinfo[saveSlotSelected].playername);

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -4922,8 +4922,8 @@ static ffloor_t *P_AddFakeFloor(sector_t *sec, sector_t *sec2, line_t *master, f
 
 	if (sec2->numattached == 0)
 	{
-		sec2->attached = Z_Malloc(sizeof (*sec2->attached) * sec2->maxattached, PU_STATIC, NULL);
-		sec2->attachedsolid = Z_Malloc(sizeof (*sec2->attachedsolid) * sec2->maxattached, PU_STATIC, NULL);
+		sec2->attached = Z_Malloc(sizeof (*sec2->attached) * sec2->maxattached, PU_LEVEL, NULL);
+		sec2->attachedsolid = Z_Malloc(sizeof (*sec2->attachedsolid) * sec2->maxattached, PU_LEVEL, NULL);
 		sec2->attached[0] = sec - sectors;
 		sec2->numattached = 1;
 		sec2->attachedsolid[0] = (flags & FF_SOLID);
@@ -4937,8 +4937,8 @@ static ffloor_t *P_AddFakeFloor(sector_t *sec, sector_t *sec2, line_t *master, f
 		if (sec2->numattached >= sec2->maxattached)
 		{
 			sec2->maxattached *= 2;
-			sec2->attached = Z_Realloc(sec2->attached, sizeof (*sec2->attached) * sec2->maxattached, PU_STATIC, NULL);
-			sec2->attachedsolid = Z_Realloc(sec2->attachedsolid, sizeof (*sec2->attachedsolid) * sec2->maxattached, PU_STATIC, NULL);
+			sec2->attached = Z_Realloc(sec2->attached, sizeof (*sec2->attached) * sec2->maxattached, PU_LEVEL, NULL);
+			sec2->attachedsolid = Z_Realloc(sec2->attachedsolid, sizeof (*sec2->attachedsolid) * sec2->maxattached, PU_LEVEL, NULL);
 		}
 		sec2->attached[sec2->numattached] = sec - sectors;
 		sec2->attachedsolid[sec2->numattached] = (flags & FF_SOLID);

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -539,7 +539,7 @@ UINT8* R_GetTranslationColormap(INT32 skinnum, skincolors_t color, UINT8 flags)
 	// Generate the colormap if necessary
 	if (!ret)
 	{
-		ret = Z_MallocAlign(NUM_PALETTE_ENTRIES, (flags & GTC_CACHE) ? PU_LEVEL : PU_STATIC, NULL, 8);
+		ret = Z_Malloc(NUM_PALETTE_ENTRIES, (flags & GTC_CACHE) ? PU_LEVEL : PU_STATIC, NULL);
 		R_GenerateTranslationColormap(ret, skinnum, color);
 
 		// Cache the colormap if desired


### PR DESCRIPTION
This patch fixes the following memory leaks:

* The texture cache in OpenGL never deallocated mipmap textures properly.
* The save menu didn't deallocate colormaps every frame.
* Attached FOFs in sectors were allocated `PU_STATIC`, so they weren't deallocated on map change.

Finally, because I was digging so damn long to find this bug, I also noticed that the binary tree used in `AATree` was not balancing properly, which could slow down reads from it. This has been fixed now by properly implementing tree balancing. For info on how to balance binary trees correctly, see https://adrianmejia.com/self-balanced-binary-search-trees-with-avl-tree-data-structure-for-beginners/