### PR TITLE
Backport the 2.2 signal handler and backtraces for Unix systems

### DIFF
--- a/src/dedicated/i_main.c
+++ b/src/dedicated/i_main.c
@@ -35,6 +35,7 @@
 
 #ifdef LOGMESSAGES
 FILE *logstream = NULL;
+char  logfilename[1024];
 #endif
 
 #ifndef DOXYGEN
@@ -78,28 +79,29 @@ int main(int argc, char **argv)
 #ifdef LOGMESSAGES
 	if (!M_CheckParm("-nolog"))
 	{
-		logdir = D_Home();
 		time_t my_time;
 		struct tm * timeinfo;
 		char buf[26];
+		logdir = D_Home();
 		my_time = time(NULL);
 		timeinfo = localtime(&my_time);
 		strftime(buf, 26, "%Y-%m-%d %H-%M-%S", timeinfo);
-		strcpy(logfile, va("log-%s.txt", buf));
+		strcpy(logfilename, va("log-%s.txt", buf));
 #ifdef DEFAULTDIR
 		if (logdir)
 		{
 			// Create dirs here because D_SRB2Main() is too late.
 			I_mkdir(va("%s%s"DEFAULTDIR, logdir, PATHSEP), 0755);
 			I_mkdir(va("%s%s"DEFAULTDIR"%slogs",logdir, PATHSEP, PATHSEP), 0755);
-			logstream = fopen(va("%s%s"DEFAULTDIR"%slogs%s%s",logdir, PATHSEP, PATHSEP, PATHSEP, logfile), "wt");
+			strcpy(logfilename, va("%s%s"DEFAULTDIR"%slogs%s%s",logdir, PATHSEP, PATHSEP, PATHSEP, logfilename));
 		}
 		else
 #endif
 		{
 			I_mkdir("."PATHSEP"logs"PATHSEP, 0755);
-			logstream = fopen(va("."PATHSEP"logs"PATHSEP"%s", logfile), "wt");
+			strcpy(logfilename, va("."PATHSEP"logs"PATHSEP"%s", logfilename));
 		}
+		logstream = fopen(logfilename, "wt");
 #endif
 	}
 	//I_OutputMsg("I_StartupSystem() ...\n");
@@ -113,8 +115,11 @@ int main(int argc, char **argv)
 	// startup SRB2
 	CONS_Printf("Setting up SRB2...\n");
 	D_SRB2Main();
+#ifdef LOGMESSAGES
+	if (!M_CheckParm("-nolog"))
+		CONS_Printf("Logfile: %s\n", logfilename);
+#endif
 	CONS_Printf("Entering main game loop...\n");
-	CONS_Printf("%s\n", logfile);
 	// never return
 	D_SRB2Loop();
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -140,6 +140,10 @@
 #define LOGMESSAGES // write message in log.txt
 #endif
 
+#if (defined (__unix__) && !defined (_MSDOS)) || defined (UNIXCOMMON)
+#define NEWSIGNALHANDLER
+#endif
+
 #ifdef LOGMESSAGES
 extern FILE *logstream;
 #endif

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -142,7 +142,8 @@
 
 #ifdef LOGMESSAGES
 extern FILE *logstream;
-extern char  logfilename[1024];
+extern FILE *crashstream;
+extern char logfilename[1024];
 #endif
 
 //#define DEVELOP // Disable this for release builds to remove excessive cheat commands and enable MD5 checking and stuff, all in one go. :3

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -142,6 +142,7 @@
 
 #ifdef LOGMESSAGES
 extern FILE *logstream;
+extern char  logfilename[1024];
 #endif
 
 //#define DEVELOP // Disable this for release builds to remove excessive cheat commands and enable MD5 checking and stuff, all in one go. :3

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -140,10 +140,6 @@
 #define LOGMESSAGES // write message in log.txt
 #endif
 
-#if (defined (__unix__) && !defined (_MSDOS)) || defined (UNIXCOMMON)
-#define NEWSIGNALHANDLER
-#endif
-
 #ifdef LOGMESSAGES
 extern FILE *logstream;
 #endif

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -142,7 +142,6 @@
 
 #ifdef LOGMESSAGES
 extern FILE *logstream;
-extern FILE *crashstream;
 extern char logfilename[1024];
 #endif
 

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -208,10 +208,6 @@ void I_StartupMouse(void);
 */
 void I_StartupMouse2(void);
 
-/**	\brief keyboard startup, shutdown, handler
-*/
-void I_StartupKeyboard(void);
-
 /**	\brief  setup timer irq and user timer routine.
 */
 void I_StartupTimer(void);

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -108,10 +108,6 @@ ticcmd_t *I_BaseTiccmd2(void);
 */
 void I_Quit(void) FUNCNORETURN;
 
-/**	\brief Print a message and text box about a signal that was raised.
-*/
-void I_ReportSignal(int num, int coredumped);
-
 typedef enum
 {
 	EvilForce = -1,

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -108,6 +108,10 @@ ticcmd_t *I_BaseTiccmd2(void);
 */
 void I_Quit(void) FUNCNORETURN;
 
+/**	\brief Print a message and text box about a signal that was raised.
+*/
+void I_ReportSignal(int num, int coredumped);
+
 typedef enum
 {
 	EvilForce = -1,

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -28,11 +28,6 @@
 
 #include "time.h" // For log timestamps
 
-#ifdef NEWSIGNALHANDLER
-#include <errno.h>
-#include <sys/wait.h>
-#endif
-
 #ifdef HAVE_SDL
 
 #ifdef HAVE_TTF
@@ -151,52 +146,6 @@ int main(int argc, char **argv)
 	prevExceptionFilter = SetUnhandledExceptionFilter(RecordExceptionInfo);
 #endif
 #endif
-
-#ifdef NEWSIGNALHANDLER
-	switch (fork())
-	{
-		case -1:
-			I_Error(
-					"Error setting up signal reporting: fork(): %s\n",
-					strerror(errno)
-			);
-			break;
-		case 0:
-			break;
-		default:
-			{
-				int status;
-				int signum;
-				if (wait(&status) == -1)
-				{
-					I_Error(
-							"Error setting up signal reporting: fork(): %s\n",
-							strerror(errno)
-					);
-				}
-				else
-				{
-					if (WIFSIGNALED (status))
-					{
-						signum = WTERMSIG (status);
-#ifdef WCOREDUMP
-						I_ReportSignal(signum, WCOREDUMP (status));
-#else
-						I_ReportSignal(signum, 0);
-#endif
-						status = 128 + signum;
-					}
-					else if (WIFEXITED (status))
-					{
-						status = WEXITSTATUS (status);
-					}
-
-					I_ShutdownSystem();
-					exit(status);
-				}
-			}
-	}
-#endif/*NEWSIGNALHANDLER*/
 
 	// startup SRB2
 	CONS_Printf("Setting up SRB2...\n");

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -47,7 +47,6 @@ extern int SDL_main(int argc, char *argv[]);
 
 #ifdef LOGMESSAGES
 FILE *logstream = NULL;
-FILE *crashstream = NULL;
 char logfilename[1024];
 #endif
 
@@ -156,9 +155,6 @@ int main(int argc, char **argv)
 	// startup SRB2
 	CONS_Printf("Setting up SRB2...\n");
 	D_SRB2Main();
-
-	crashstream = fopen(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), "at");
-
 #ifdef LOGMESSAGES
 	if (!M_CheckParm("-nolog"))
 		CONS_Printf("Logfile: %s\n", logfilename);

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -47,6 +47,7 @@ extern int SDL_main(int argc, char *argv[]);
 
 #ifdef LOGMESSAGES
 FILE *logstream = NULL;
+char  logfilename[1024];
 #endif
 
 #ifndef DOXYGEN
@@ -82,7 +83,6 @@ int main(int argc, char **argv)
 #endif
 {
 	const char *logdir = NULL;
-	char logfile[MAX_WADPATH];
 	myargc = argc;
 	myargv = argv; /// \todo pull out path to exe from this string
 
@@ -97,35 +97,40 @@ int main(int argc, char **argv)
 #endif
 #endif
 
-	
-
 #ifdef LOGMESSAGES
 	if (!M_CheckParm("-nolog"))
 	{
-		logdir = D_Home();
 		time_t my_time;
 		struct tm * timeinfo;
 		char buf[26];
+
+		logdir = D_Home();
+
 		my_time = time(NULL);
 		timeinfo = localtime(&my_time);
+
 		strftime(buf, 26, "%Y-%m-%d %H-%M-%S", timeinfo);
-		strcpy(logfile, va("log-%s.txt", buf));
+		strcpy(logfilename, va("log-%s.txt", buf));
+
 #ifdef DEFAULTDIR
 		if (logdir)
 		{
 			// Create dirs here because D_SRB2Main() is too late.
 			I_mkdir(va("%s%s"DEFAULTDIR, logdir, PATHSEP), 0755);
 			I_mkdir(va("%s%s"DEFAULTDIR"%slogs",logdir, PATHSEP, PATHSEP), 0755);
-			logstream = fopen(va("%s%s"DEFAULTDIR"%slogs%s%s",logdir, PATHSEP, PATHSEP, PATHSEP, logfile), "wt");
+			strcpy(logfilename, va("%s%s"DEFAULTDIR"%slogs%s%s",logdir, PATHSEP, PATHSEP, PATHSEP, logfilename));
 		}
 		else
 #endif
 		{
 			I_mkdir("."PATHSEP"logs"PATHSEP, 0755);
-			logstream = fopen(va("."PATHSEP"logs"PATHSEP"%s", logfile), "wt");
+			strcpy(logfilename, va("."PATHSEP"logs"PATHSEP"%s", logfilename));
 		}
-#endif
+
+		logstream = fopen(logfilename, "wt");
 	}
+#endif
+
 	//I_OutputMsg("I_StartupSystem() ...\n");
 	I_StartupSystem();
 #if defined (_WIN32)
@@ -150,8 +155,11 @@ int main(int argc, char **argv)
 	// startup SRB2
 	CONS_Printf("Setting up SRB2...\n");
 	D_SRB2Main();
+#ifdef LOGMESSAGES
+	if (!M_CheckParm("-nolog"))
+		CONS_Printf("Logfile: %s\n", logfilename);
+#endif
 	CONS_Printf("Entering main game loop...\n");
-	CONS_Printf("%s\n", logfile);
 	// never return
 	D_SRB2Loop();
 

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -47,7 +47,8 @@ extern int SDL_main(int argc, char *argv[]);
 
 #ifdef LOGMESSAGES
 FILE *logstream = NULL;
-char  logfilename[1024];
+FILE *crashstream = NULL;
+char logfilename[1024];
 #endif
 
 #ifndef DOXYGEN
@@ -155,6 +156,9 @@ int main(int argc, char **argv)
 	// startup SRB2
 	CONS_Printf("Setting up SRB2...\n");
 	D_SRB2Main();
+
+	crashstream = fopen(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), "at");
+
 #ifdef LOGMESSAGES
 	if (!M_CheckParm("-nolog"))
 		CONS_Printf("Logfile: %s\n", logfilename);

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -28,6 +28,11 @@
 
 #include "time.h" // For log timestamps
 
+#ifdef NEWSIGNALHANDLER
+#include <errno.h>
+#include <sys/wait.h>
+#endif
+
 #ifdef HAVE_SDL
 
 #ifdef HAVE_TTF
@@ -146,6 +151,53 @@ int main(int argc, char **argv)
 	prevExceptionFilter = SetUnhandledExceptionFilter(RecordExceptionInfo);
 #endif
 #endif
+
+#ifdef NEWSIGNALHANDLER
+	switch (fork())
+	{
+		case -1:
+			I_Error(
+					"Error setting up signal reporting: fork(): %s\n",
+					strerror(errno)
+			);
+			break;
+		case 0:
+			break;
+		default:
+			{
+				int status;
+				int signum;
+				if (wait(&status) == -1)
+				{
+					I_Error(
+							"Error setting up signal reporting: fork(): %s\n",
+							strerror(errno)
+					);
+				}
+				else
+				{
+					if (WIFSIGNALED (status))
+					{
+						signum = WTERMSIG (status);
+#ifdef WCOREDUMP
+						I_ReportSignal(signum, WCOREDUMP (status));
+#else
+						I_ReportSignal(signum, 0);
+#endif
+						status = 128 + signum;
+					}
+					else if (WIFEXITED (status))
+					{
+						status = WEXITSTATUS (status);
+					}
+
+					I_ShutdownSystem();
+					exit(status);
+				}
+			}
+	}
+#endif/*NEWSIGNALHANDLER*/
+
 	// startup SRB2
 	CONS_Printf("Setting up SRB2...\n");
 	D_SRB2Main();

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2235,6 +2235,7 @@ static void I_Fork(void)
 	int child;
 	int status;
 	int signum;
+	int c;
 
 	child = fork();
 
@@ -2246,7 +2247,19 @@ static void I_Fork(void)
 		case 0:
 			break;
 		default:
-			if (wait(&status) == -1)
+			if (logstream)
+				fclose(logstream);/* the child has this */
+
+			c = wait(&status);
+
+#ifdef LOGMESSAGES
+			/* By the way, exit closes files. */
+			logstream = fopen(logfilename, "at");
+#else
+			logstream = 0;
+#endif
+
+			if (c == -1)
 			{
 				kill(child, SIGKILL);
 				newsignalhandler_Warn("wait()");

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2212,9 +2212,13 @@ void I_SleepDuration(precise_t duration)
 #ifdef NEWSIGNALHANDLER
 static void I_Fork(void)
 {
+	int child;
 	int status;
 	int signum;
-	switch (fork())
+
+	child = fork();
+
+	switch (child)
 	{
 		case -1:
 			I_Error(
@@ -2227,6 +2231,7 @@ static void I_Fork(void)
 		default:
 			if (wait(&status) == -1)
 			{
+				kill(child, SIGKILL);
 				I_Error(
 						"Error setting up signal reporting: fork(): %s\n",
 						strerror(errno)

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -294,11 +294,11 @@ static void I_ReportSignal(int num, int coredumped)
 		sigmsg = msg;
 	}
 
-	I_OutputMsg("\nsignal_handler() error: %s\n", sigmsg);
+	I_OutputMsg("\nProcess killed by signal: %s\n\n", sigmsg);
 
 	if (!M_CheckParm("-dedicated"))
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
-			"Signal caught",
+			"Process killed by signal",
 			sigmsg, NULL);
 }
 

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -139,12 +139,15 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #include <errno.h>
 #endif
 
-// Locations for searching the srb2.srb
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
+#ifndef NOEXECINFO
 #include <execinfo.h>
+#endif
 #include <time.h>
+#define UNIXBACKTRACE
 #endif
 
+// Locations for searching the srb2.srb
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
 #include <execinfo.h>
 #include <time.h>
@@ -260,28 +263,29 @@ UINT8 keyboard_started = false;
 
 #ifdef UNIXBACKTRACE
 
-// NOTE: if written ends up ever being -1, all further writes end up being cancelled.
-// i figure an error is a reason to stop writing...
-#define WRITE_FILE(string) \
-	sourcelen = strlen(string); \
-	while (fd != -1 && (written != -1 && errno != EINTR) && written < sourcelen) \
+static void bt_write_file(int fd, const char *string) {
+	ssize_t written = 0;
+	ssize_t sourcelen = strlen(string);
+
+	while (fd != -1 && (written != -1 && errno != EINTR) && written < sourcelen)
 		written = write(fd, string, sourcelen);
+}
 
-#define WRITE_STDERR(string) \
-	I_OutputMsg("%s", string);
+static void bt_write_stderr(const char *string) {
+	bt_write_file(STDERR_FILENO, string);
+}
 
-#define WRITE_ALL(string) \
-	WRITE_FILE(string); \
-	WRITE_STDERR(string);
+static void bt_write_all(int fd, const char *string) {
+	bt_write_file(fd, string);
+	bt_write_file(STDERR_FILENO, string);
+}
 
 static void write_backtrace(INT32 signal)
 {
 	int fd = -1;
-	ssize_t written = 0;
-	ssize_t sourcelen = 0;
 	time_t rawtime;
 	struct tm timeinfo;
-	size_t size;
+	size_t bt_size;
 
 	enum { BT_SIZE = 1024, STR_SIZE = 32 };
 	void *funcptrs[BT_SIZE];
@@ -292,49 +296,47 @@ static void write_backtrace(INT32 signal)
 	fd = open(filename, O_CREAT|O_APPEND|O_RDWR, S_IRUSR|S_IWUSR);
 
 	if (fd == -1) // File handle error
-		WRITE_STDERR("\nWARNING: Couldn't open crash log for writing! Make sure your permissions are correct. Please save the below report!\n");
+		bt_write_stderr("\nWARNING: Couldn't open crash log for writing! Make sure your permissions are correct. Please save the below report!\n");
 
 	// Get the current time as a string.
 	time(&rawtime);
 	localtime_r(&rawtime, &timeinfo);
 	strftime(timestr, STR_SIZE, "%a, %d %b %Y %T %z", &timeinfo);
 
-	WRITE_FILE("------------------------\n"); // Nice looking seperator
+	bt_write_file(fd, "------------------------\n"); // Nice looking seperator
 
-	WRITE_ALL("\n"); // Newline to look nice for both outputs.
-	WRITE_ALL("An error occurred within SRB2! Send this stack trace to someone who can help!\n");
+	bt_write_all(fd, "\n"); // Newline to look nice for both outputs.
+	bt_write_all(fd, "An error occurred within SRB2! Send this stack trace to someone who can help!\n");
 
 	if (fd != -1) // If the crash log exists,
-		WRITE_STDERR("(Or find crash-log.txt in your SRB2 directory.)\n"); // tell the user where the crash log is.
+		bt_write_stderr("(Or find crash-log.txt in your SRB2 directory.)\n"); // tell the user where the crash log is.
 
 	// Tell the log when we crashed.
-	WRITE_FILE("Time of crash: ");
-	WRITE_FILE(timestr);
-	WRITE_FILE("\n");
+	bt_write_file(fd, "Time of crash: ");
+	bt_write_file(fd, timestr);
+	bt_write_file(fd, "\n");
 
 	// Give the crash log the cause and a nice 'Backtrace:' thing
 	// The signal is given to the user when the parent process sees we crashed.
-	WRITE_FILE("Cause: ");
-	WRITE_FILE(strsignal(signal));
-	WRITE_FILE("\n"); // Newline for the signal name
+	bt_write_file(fd, "Cause: ");
+	bt_write_file(fd, strsignal(signal));
+	bt_write_file(fd, "\n"); // Newline for the signal name
 
-	WRITE_ALL("\nBacktrace:\n");
+	bt_write_all(fd, "\nBacktrace:\n");
 
 	// Flood the output and log with the backtrace
-	size = backtrace(funcptrs, BT_SIZE);
-	backtrace_symbols_fd(funcptrs, size, fd);
-	backtrace_symbols_fd(funcptrs, size, STDERR_FILENO);
+	bt_size = backtrace(funcptrs, BT_SIZE);
+	backtrace_symbols_fd(funcptrs, bt_size, fd);
+	backtrace_symbols_fd(funcptrs, bt_size, STDERR_FILENO);
 
-	WRITE_FILE("\n"); // Write another newline to the log so it looks nice :)
+	bt_write_file(fd, "\n"); // Write another newline to the log so it looks nice :)
 
 	if (fd != -1) {
 		fsync(fd); // reaaaaally make sure we got that data written.
 		close(fd);
 	}
 }
-#undef WRITE_FILE
-#undef WRITE_STDERR
-#undef WRITE_ALL
+
 #endif // UNIXBACKTRACE
 
 

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -104,6 +104,12 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #endif
 #endif
 
+#if (defined (__unix__) && !defined (_MSDOS)) || defined (UNIXCOMMON)
+#include <errno.h>
+#include <sys/wait.h>
+#define NEWSIGNALHANDLER
+#endif
+
 #ifndef NOMUMBLE
 #ifdef __linux__ // need -lrt
 #include <sys/mman.h>
@@ -241,7 +247,7 @@ SDL_bool framebuffer = SDL_FALSE;
 
 UINT8 keyboard_started = false;
 
-void I_ReportSignal(int num, int coredumped)
+static void I_ReportSignal(int num, int coredumped)
 {
 	//static char msg[] = "oh no! back to reality!\r\n";
 	const char *      sigmsg;
@@ -2203,6 +2209,53 @@ void I_SleepDuration(precise_t duration)
 
 
 
+#ifdef NEWSIGNALHANDLER
+static void I_Fork(void)
+{
+	int status;
+	int signum;
+	switch (fork())
+	{
+		case -1:
+			I_Error(
+					"Error setting up signal reporting: fork(): %s\n",
+					strerror(errno)
+			);
+			break;
+		case 0:
+			break;
+		default:
+			if (wait(&status))
+			{
+				I_Error(
+						"Error setting up signal reporting: fork(): %s\n",
+						strerror(errno)
+				);
+			}
+			else
+			{
+				if (WIFSIGNALED (status))
+				{
+					signum = WTERMSIG (status);
+#ifdef WCOREDUMP
+					I_ReportSignal(signum, WCOREDUMP (status));
+#else
+					I_ReportSignal(signum, 0);
+#endif
+					status = 128 + signum;
+				}
+				else if (WIFEXITED (status))
+				{
+					status = WEXITSTATUS (status);
+				}
+
+				I_ShutdownSystem();
+				exit(status);
+			}
+	}
+}
+#endif/*NEWSIGNALHANDLER*/
+
 INT32 I_StartupSystem(void)
 {
 	SDL_version SDLcompiled;
@@ -2210,6 +2263,9 @@ INT32 I_StartupSystem(void)
 	SDL_VERSION(&SDLcompiled)
 	SDL_GetVersion(&SDLlinked);
 	I_StartupConsole();
+#ifdef NEWSIGNALHANDLER
+	I_Fork();
+#endif
 	I_OutputMsg("Compiled for SDL version: %d.%d.%d\n",
 	 SDLcompiled.major, SDLcompiled.minor, SDLcompiled.patch);
 	I_OutputMsg("Linked with SDL version: %d.%d.%d\n",

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -271,10 +271,11 @@ static void write_backtrace(INT32 signal)
 	int fd = -1;
 	size_t size;
 	time_t rawtime;
-	struct tm * timeinfo;
+	struct tm timeinfo;
 
-	enum { MAX_SIZE = 1024 };
-	void *array[MAX_SIZE];
+	enum { BT_SIZE = 1024, STR_SIZE = 32 };
+	void *array[BT_SIZE];
+	char timestr[STR_SIZE];
 
 	const char *error = "An error occurred within SRB2! Send this stack trace to someone who can help!\n";
 	const char *error2 = "(Or find crash-log.txt in your SRB2 directory.)\n"; // Shown only to stderr.
@@ -284,8 +285,10 @@ static void write_backtrace(INT32 signal)
 	if (fd == -1)
 		I_OutputMsg("\nWARNING: Couldn't open crash log for writing! Make sure your permissions are correct. Please save the below report!\n");
 
+	// Get the current time as a string.
 	time(&rawtime);
-	timeinfo = localtime(&rawtime);
+	localtime_r(&rawtime, &timeinfo);
+	strftime(timestr, STR_SIZE, "%a, %d %b %Y %T %z", &timeinfo);
 
 	CRASHLOG_WRITE("------------------------\n"); // Nice looking seperator
 
@@ -295,7 +298,8 @@ static void write_backtrace(INT32 signal)
 
 	// Tell the log when we crashed.
 	CRASHLOG_WRITE("Time of crash: ");
-	CRASHLOG_WRITE(asctime(timeinfo));
+	CRASHLOG_WRITE(timestr);
+	CRASHLOG_WRITE("\n");
 
 	// Give the crash log the cause and a nice 'Backtrace:' thing
 	// The signal is given to the user when the parent process sees we crashed.
@@ -305,8 +309,8 @@ static void write_backtrace(INT32 signal)
 
 	CRASHLOG_STDERR_WRITE("\nBacktrace:\n");
 
-		// Flood the output and log with the backtrace
-	size = backtrace(array, MAX_SIZE);
+	// Flood the output and log with the backtrace
+	size = backtrace(array, BT_SIZE);
 	backtrace_symbols_fd(array, size, fd);
 	backtrace_symbols_fd(array, size, STDERR_FILENO);
 

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2225,7 +2225,7 @@ static void I_Fork(void)
 		case 0:
 			break;
 		default:
-			if (wait(&status))
+			if (wait(&status) == -1)
 			{
 				I_Error(
 						"Error setting up signal reporting: fork(): %s\n",

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2296,7 +2296,10 @@ INT32 I_StartupSystem(void)
 	SDL_GetVersion(&SDLlinked);
 	I_StartupConsole();
 #ifdef NEWSIGNALHANDLER
-	I_Fork();
+	// This is useful when debugging. It lets GDB attach to
+	// the correct process easily.
+	if (!M_CheckParm("-nofork"))
+		I_Fork();
 #endif
 	I_RegisterSignals();
 	I_OutputMsg("Compiled for SDL version: %d.%d.%d\n",
@@ -2541,8 +2544,10 @@ void I_ShutdownSystem(void)
 	INT32 c;
 
 #ifndef NEWSIGNALHANDLER
-	I_ShutdownConsole();
+	if (M_CheckParm("-nofork"))
 #endif
+		I_ShutdownConsole();
+
 
 	for (c = MAX_QUIT_FUNCS-1; c >= 0; c--)
 		if (quit_funcs[c])

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -141,6 +141,17 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 
 // Locations for searching the srb2.srb
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
+#include <execinfo.h>
+#include <time.h>
+#endif
+
+#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
+#include <execinfo.h>
+#include <time.h>
+#endif
+ 
+// Locations for searching the srb2.srb 
+#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
 #define DEFAULTWADLOCATION1 "/usr/local/share/games/SRB2legacy"
 #define DEFAULTWADLOCATION2 "/usr/local/games/SRB2legacy"
 #define DEFAULTWADLOCATION3 "/usr/share/games/SRB2legacy"
@@ -247,6 +258,75 @@ SDL_bool framebuffer = SDL_FALSE;
 
 UINT8 keyboard_started = false;
 
+#define STDERR_WRITE(string) if (fd != -1) I_OutputMsg("%s", string)
+#define CRASHLOG_WRITE(string) if (fd != -1) write(fd, string, strlen(string))
+#define CRASHLOG_STDERR_WRITE(string) \
+	if (fd != -1)\
+		write(fd, string, strlen(string));\
+	I_OutputMsg("%s", string)
+
+static void write_backtrace(INT32 signal)
+{
+#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
+	int fd = -1;
+	size_t size;
+	time_t rawtime;
+	struct tm * timeinfo;
+
+	enum { MAX_SIZE = 1024 };
+	void *array[MAX_SIZE];
+
+	const char *error = "An error occurred within SRB2! Send this stack trace to someone who can help!\n";
+	const char *error2 = "(Or find crash-log.txt in your SRB2 directory.)\n"; // Shown only to stderr.
+
+	if (!crashstream)
+		crashstream = fopen(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), "at");
+
+	if (!crashstream)
+		I_OutputMsg("\nWARNING: Couldn't open crash log for writing! Make sure your permissions are correct. Please save the below report!\n");
+	else
+	{
+		fd = fileno(crashstream);
+
+		if (fd == -1)
+			fd = open(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), O_CREAT|O_APPEND);
+	}
+
+	time(&rawtime);
+	timeinfo = localtime(&rawtime);
+
+	CRASHLOG_WRITE("------------------------\n"); // Nice looking seperator
+
+	CRASHLOG_STDERR_WRITE("\n"); // Newline to look nice for both outputs.
+	CRASHLOG_STDERR_WRITE(error); // "Oops, SRB2 crashed" message
+	STDERR_WRITE(error2); // Tell the user where the crash log is.
+
+	// Tell the log when we crashed.
+	CRASHLOG_WRITE("Time of crash: ");
+	CRASHLOG_WRITE(asctime(timeinfo));
+
+	// Give the crash log the cause and a nice 'Backtrace:' thing
+	// The signal is given to the user when the parent process sees we crashed.
+	CRASHLOG_WRITE("Cause: ");
+	CRASHLOG_WRITE(strsignal(signal));
+	CRASHLOG_WRITE("\n"); // Newline for the signal name
+
+	CRASHLOG_STDERR_WRITE("\nBacktrace:\n");
+
+		// Flood the output and log with the backtrace
+	size = backtrace(array, MAX_SIZE);
+	backtrace_symbols_fd(array, size, fd);
+	backtrace_symbols_fd(array, size, STDERR_FILENO);
+
+	CRASHLOG_WRITE("\n"); // Write another newline to the log so it looks nice :)
+
+	close(fd);
+#endif
+}
+#undef STDERR_WRITE
+#undef CRASHLOG_WRITE
+#undef CRASHLOG_STDERR_WRITE
+
 static void I_ReportSignal(int num, int coredumped)
 {
 	//static char msg[] = "oh no! back to reality!\r\n";
@@ -307,6 +387,9 @@ FUNCNORETURN static ATTRNORETURN void signal_handler(INT32 num)
 {
 	D_QuitNetGame(); // Fix server freezes
 	I_ReportSignal(num, 0);
+
+	write_backtrace(num);
+
 	I_ShutdownSystem();
 	signal(num, SIG_DFL);               //default signal action
 	raise(num);
@@ -718,6 +801,26 @@ void I_RegisterSignals (void)
 	signal(SIGFPE , signal_handler);
 #endif
 }
+
+#ifdef NEWSIGNALHANDLER
+static void signal_handler_child(INT32 num)
+{
+	write_backtrace(num);
+
+	signal(num, SIG_DFL);               //default signal action
+	raise(num);
+}
+
+static void I_RegisterChildSignals(void)
+{
+	// If these defines don't exist,
+	// then compilation would have failed above us...
+	signal(SIGILL , signal_handler_child);
+	signal(SIGSEGV , signal_handler_child);
+	signal(SIGABRT , signal_handler_child);
+	signal(SIGFPE , signal_handler_child);
+}
+#endif
 
 //
 //I_OutputMsg
@@ -2245,6 +2348,7 @@ static void I_Fork(void)
 			newsignalhandler_Warn("fork()");
 			break;
 		case 0:
+			I_RegisterChildSignals();
 			break;
 		default:
 			if (logstream)

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2210,6 +2210,26 @@ void I_SleepDuration(precise_t duration)
 
 
 #ifdef NEWSIGNALHANDLER
+static void newsignalhandler_Warn(const char *pr)
+{
+	char text[128];
+
+	snprintf(text, sizeof text,
+			"Error while setting up signal reporting: %s: %s",
+			pr,
+			strerror(errno)
+	);
+
+	I_OutputMsg("%s\n", text);
+
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+		"Startup error",
+		text, NULL);
+
+	I_ShutdownConsole();
+	exit(-1);
+}
+
 static void I_Fork(void)
 {
 	int child;
@@ -2221,10 +2241,7 @@ static void I_Fork(void)
 	switch (child)
 	{
 		case -1:
-			I_Error(
-					"Error setting up signal reporting: fork(): %s\n",
-					strerror(errno)
-			);
+			newsignalhandler_Warn("fork()");
 			break;
 		case 0:
 			break;
@@ -2232,10 +2249,7 @@ static void I_Fork(void)
 			if (wait(&status) == -1)
 			{
 				kill(child, SIGKILL);
-				I_Error(
-						"Error setting up signal reporting: fork(): %s\n",
-						strerror(errno)
-				);
+				newsignalhandler_Warn("wait()");
 			}
 			else
 			{
@@ -2254,7 +2268,7 @@ static void I_Fork(void)
 					status = WEXITSTATUS (status);
 				}
 
-				I_ShutdownSystem();
+				I_ShutdownConsole();
 				exit(status);
 			}
 	}
@@ -2512,8 +2526,6 @@ void I_RemoveExitFunc(void (*func)())
 void I_ShutdownSystem(void)
 {
 	INT32 c;
-
-	I_ShutdownConsole();
 
 	for (c = MAX_QUIT_FUNCS-1; c >= 0; c--)
 		if (quit_funcs[c])

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -104,7 +104,7 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #endif
 #endif
 
-#if (defined (__unix__) && !defined (_MSDOS)) || defined (UNIXCOMMON)
+#if (defined (__unix__) && !defined (_MSDOS)) || (defined (UNIXCOMMON) && !defined(__APPLE__))
 #include <errno.h>
 #include <sys/wait.h>
 #define NEWSIGNALHANDLER

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -258,70 +258,86 @@ SDL_bool framebuffer = SDL_FALSE;
 
 UINT8 keyboard_started = false;
 
-#define STDERR_WRITE(string) if (fd != -1) I_OutputMsg("%s", string)
-#define CRASHLOG_WRITE(string) if (fd != -1) write(fd, string, strlen(string))
-#define CRASHLOG_STDERR_WRITE(string) \
-	if (fd != -1)\
-		write(fd, string, strlen(string));\
-	I_OutputMsg("%s", string)
+#ifdef UNIXBACKTRACE
+
+// NOTE: if written ends up ever being -1, all further writes end up being cancelled.
+// i figure an error is a reason to stop writing...
+#define WRITE_FILE(string) \
+	sourcelen = strlen(string); \
+	while (fd != -1 && (written != -1 && errno != EINTR) && written < sourcelen) \
+		written = write(fd, string, sourcelen);
+
+#define WRITE_STDERR(string) \
+	I_OutputMsg("%s", string);
+
+#define WRITE_ALL(string) \
+	WRITE_FILE(string); \
+	WRITE_STDERR(string);
 
 static void write_backtrace(INT32 signal)
 {
-#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
 	int fd = -1;
-	size_t size;
+	ssize_t written = 0;
+	ssize_t sourcelen = 0;
 	time_t rawtime;
 	struct tm timeinfo;
+	size_t size;
 
 	enum { BT_SIZE = 1024, STR_SIZE = 32 };
-	void *array[BT_SIZE];
+	void *funcptrs[BT_SIZE];
 	char timestr[STR_SIZE];
 
-	const char *error = "An error occurred within SRB2! Send this stack trace to someone who can help!\n";
-	const char *error2 = "(Or find crash-log.txt in your SRB2 directory.)\n"; // Shown only to stderr.
+	const char *filename = va("%s" PATHSEP "%s", srb2home, "crash-log.txt");
 
-	fd = open(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), O_CREAT|O_APPEND|O_RDWR, S_IRUSR|S_IWUSR);
+	fd = open(filename, O_CREAT|O_APPEND|O_RDWR, S_IRUSR|S_IWUSR);
 
-	if (fd == -1)
-		I_OutputMsg("\nWARNING: Couldn't open crash log for writing! Make sure your permissions are correct. Please save the below report!\n");
+	if (fd == -1) // File handle error
+		WRITE_STDERR("\nWARNING: Couldn't open crash log for writing! Make sure your permissions are correct. Please save the below report!\n");
 
 	// Get the current time as a string.
 	time(&rawtime);
 	localtime_r(&rawtime, &timeinfo);
 	strftime(timestr, STR_SIZE, "%a, %d %b %Y %T %z", &timeinfo);
 
-	CRASHLOG_WRITE("------------------------\n"); // Nice looking seperator
+	WRITE_FILE("------------------------\n"); // Nice looking seperator
 
-	CRASHLOG_STDERR_WRITE("\n"); // Newline to look nice for both outputs.
-	CRASHLOG_STDERR_WRITE(error); // "Oops, SRB2 crashed" message
-	STDERR_WRITE(error2); // Tell the user where the crash log is.
+	WRITE_ALL("\n"); // Newline to look nice for both outputs.
+	WRITE_ALL("An error occurred within SRB2! Send this stack trace to someone who can help!\n");
+
+	if (fd != -1) // If the crash log exists,
+		WRITE_STDERR("(Or find crash-log.txt in your SRB2 directory.)\n"); // tell the user where the crash log is.
 
 	// Tell the log when we crashed.
-	CRASHLOG_WRITE("Time of crash: ");
-	CRASHLOG_WRITE(timestr);
-	CRASHLOG_WRITE("\n");
+	WRITE_FILE("Time of crash: ");
+	WRITE_FILE(timestr);
+	WRITE_FILE("\n");
 
 	// Give the crash log the cause and a nice 'Backtrace:' thing
 	// The signal is given to the user when the parent process sees we crashed.
-	CRASHLOG_WRITE("Cause: ");
-	CRASHLOG_WRITE(strsignal(signal));
-	CRASHLOG_WRITE("\n"); // Newline for the signal name
+	WRITE_FILE("Cause: ");
+	WRITE_FILE(strsignal(signal));
+	WRITE_FILE("\n"); // Newline for the signal name
 
-	CRASHLOG_STDERR_WRITE("\nBacktrace:\n");
+	WRITE_ALL("\nBacktrace:\n");
 
 	// Flood the output and log with the backtrace
-	size = backtrace(array, BT_SIZE);
-	backtrace_symbols_fd(array, size, fd);
-	backtrace_symbols_fd(array, size, STDERR_FILENO);
+	size = backtrace(funcptrs, BT_SIZE);
+	backtrace_symbols_fd(funcptrs, size, fd);
+	backtrace_symbols_fd(funcptrs, size, STDERR_FILENO);
 
-	CRASHLOG_WRITE("\n"); // Write another newline to the log so it looks nice :)
+	WRITE_FILE("\n"); // Write another newline to the log so it looks nice :)
 
-	close(fd);
-#endif
+	if (fd != -1) {
+		fsync(fd); // reaaaaally make sure we got that data written.
+		close(fd);
+	}
 }
-#undef STDERR_WRITE
-#undef CRASHLOG_WRITE
-#undef CRASHLOG_STDERR_WRITE
+#undef WRITE_FILE
+#undef WRITE_STDERR
+#undef WRITE_ALL
+#endif // UNIXBACKTRACE
+
+
 
 static void I_ReportSignal(int num, int coredumped)
 {
@@ -382,7 +398,9 @@ static void I_ReportSignal(int num, int coredumped)
 FUNCNORETURN static ATTRNORETURN void signal_handler(INT32 num)
 {
 	D_QuitNetGame(); // Fix server freezes
+#ifdef UNIXBACKTRACE
 	write_backtrace(num);
+#endif
 	I_ReportSignal(num, 0);
 	I_ShutdownSystem();
 	signal(num, SIG_DFL);               //default signal action
@@ -799,7 +817,9 @@ void I_RegisterSignals (void)
 #ifdef NEWSIGNALHANDLER
 static void signal_handler_child(INT32 num)
 {
+#ifdef UNIXBACKTRACE
 	write_backtrace(num);
+#endif
 
 	signal(num, SIG_DFL);               //default signal action
 	raise(num);

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2527,6 +2527,10 @@ void I_ShutdownSystem(void)
 {
 	INT32 c;
 
+#ifndef NEWSIGNALHANDLER
+	I_ShutdownConsole();
+#endif
+
 	for (c = MAX_QUIT_FUNCS-1; c >= 0; c--)
 		if (quit_funcs[c])
 			(*quit_funcs[c])();

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -241,13 +241,11 @@ SDL_bool framebuffer = SDL_FALSE;
 
 UINT8 keyboard_started = false;
 
-FUNCNORETURN static ATTRNORETURN void signal_handler(INT32 num)
+void I_ReportSignal(int num, int coredumped)
 {
 	//static char msg[] = "oh no! back to reality!\r\n";
 	const char *      sigmsg;
-	char        sigdef[32];
-
-	D_QuitNetGame(); // Fix server freezes
+	char msg[128];
 
 	switch (num)
 	{
@@ -273,8 +271,21 @@ FUNCNORETURN static ATTRNORETURN void signal_handler(INT32 num)
 		sigmsg = "SIGABRT - abnormal termination triggered by abort call";
 		break;
 	default:
-		sprintf(sigdef,"signal number %d", num);
-		sigmsg = sigdef;
+		sprintf(msg,"signal number %d", num);
+		if (coredumped)
+			sigmsg = 0;
+		else
+			sigmsg = msg;
+	}
+
+	if (coredumped)
+	{
+		if (sigmsg)
+			sprintf(msg, "%s (core dumped)", sigmsg);
+		else
+			strcat(msg, " (core dumped)");
+
+		sigmsg = msg;
 	}
 
 	I_OutputMsg("\nsignal_handler() error: %s\n", sigmsg);
@@ -283,11 +294,19 @@ FUNCNORETURN static ATTRNORETURN void signal_handler(INT32 num)
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
 			"Signal caught",
 			sigmsg, NULL);
+}
+
+#ifndef NEWSIGNALHANDLER
+FUNCNORETURN static ATTRNORETURN void signal_handler(INT32 num)
+{
+	D_QuitNetGame(); // Fix server freezes
+	I_ReportSignal(num, 0);
 	I_ShutdownSystem();
 	signal(num, SIG_DFL);               //default signal action
 	raise(num);
 	I_Quit();
 }
+#endif
 
 FUNCNORETURN static ATTRNORETURN void quit_handler(int num)
 {
@@ -686,10 +705,12 @@ void I_StartupKeyboard (void)
 
 	// If these defines don't exist,
 	// then compilation would have failed above us...
+#ifndef NEWSIGNALHANDLER
 	signal(SIGILL , signal_handler);
 	signal(SIGSEGV , signal_handler);
 	signal(SIGABRT , signal_handler);
 	signal(SIGFPE , signal_handler);
+#endif
 }
 
 //

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -279,18 +279,10 @@ static void write_backtrace(INT32 signal)
 	const char *error = "An error occurred within SRB2! Send this stack trace to someone who can help!\n";
 	const char *error2 = "(Or find crash-log.txt in your SRB2 directory.)\n"; // Shown only to stderr.
 
-	if (!crashstream)
-		crashstream = fopen(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), "at");
+	fd = open(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), O_CREAT|O_APPEND|O_RDWR, S_IRUSR|S_IWUSR);
 
-	if (!crashstream)
+	if (fd == -1)
 		I_OutputMsg("\nWARNING: Couldn't open crash log for writing! Make sure your permissions are correct. Please save the below report!\n");
-	else
-	{
-		fd = fileno(crashstream);
-
-		if (fd == -1)
-			fd = open(va("%s" PATHSEP "%s", srb2home, "crash-log.txt"), O_CREAT|O_APPEND);
-	}
 
 	time(&rawtime);
 	timeinfo = localtime(&rawtime);

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -107,7 +107,9 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #if (defined (__unix__) && !defined (_MSDOS)) || (defined (UNIXCOMMON) && !defined(__APPLE__))
 #include <errno.h>
 #include <sys/wait.h>
+#ifndef __HAIKU__ // haiku's crash dialog is just objectively better
 #define NEWSIGNALHANDLER
+#endif
 #endif
 
 #ifndef NOMUMBLE
@@ -147,11 +149,7 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #define UNIXBACKTRACE
 #endif
 
-// Locations for searching the srb2.srb
-#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
-#include <execinfo.h>
-#include <time.h>
-#endif
+
  
 // Locations for searching the srb2.srb 
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -697,7 +697,7 @@ static inline void I_ShutdownConsole(void){}
 //
 // StartupKeyboard
 //
-void I_StartupKeyboard (void)
+void I_RegisterSignals (void)
 {
 #ifdef SIGINT
 	signal(SIGINT , quit_handler);
@@ -2271,6 +2271,7 @@ INT32 I_StartupSystem(void)
 #ifdef NEWSIGNALHANDLER
 	I_Fork();
 #endif
+	I_RegisterSignals();
 	I_OutputMsg("Compiled for SDL version: %d.%d.%d\n",
 	 SDLcompiled.major, SDLcompiled.minor, SDLcompiled.patch);
 	I_OutputMsg("Linked with SDL version: %d.%d.%d\n",

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -378,10 +378,8 @@ static void I_ReportSignal(int num, int coredumped)
 FUNCNORETURN static ATTRNORETURN void signal_handler(INT32 num)
 {
 	D_QuitNetGame(); // Fix server freezes
-	I_ReportSignal(num, 0);
-
 	write_backtrace(num);
-
+	I_ReportSignal(num, 0);
 	I_ShutdownSystem();
 	signal(num, SIG_DFL);               //default signal action
 	raise(num);

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2212,7 +2212,6 @@ void I_Quit(void)
 	if (quiting) goto death;
 	SDLforceUngrabMouse();
 	quiting = SDL_FALSE;
-	I_ShutdownConsole();
 	M_SaveConfig(NULL); //save game config, cvars..
 #ifndef NONET
 	D_SaveBan(); // save the ban list
@@ -2331,8 +2330,6 @@ void I_Error(const char *error, ...)
 	I_OutputMsg("\nI_Error(): %s\n", buffer);
 	// ---
 
-	I_ShutdownConsole();
-
 	M_SaveConfig(NULL); // save game config, cvars..
 #ifndef NONET
 	D_SaveBan(); // save the ban list
@@ -2432,6 +2429,8 @@ void I_RemoveExitFunc(void (*func)())
 void I_ShutdownSystem(void)
 {
 	INT32 c;
+
+	I_ShutdownConsole();
 
 	for (c = MAX_QUIT_FUNCS-1; c >= 0; c--)
 		if (quit_funcs[c])


### PR DESCRIPTION
This patch adds the new signal handler from [!530](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/530) which adds a forked signal handler which can be disabled with the `-nofork` command line parameter. Also adds backtrace support from [!1288](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/1288) which prints a backtrace whenever the game crashes