### PR TITLE
Fix remaining leaks

### DIFF
--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1546,7 +1546,7 @@ static void HU_drawChatLog(INT32 offset)
 	{
 		INT32 clrflag = 0;
 		INT32 j = 0;
-		const char *msg = CHAT_WordWrap(x+2, boxw-(charwidth*2), V_SNAPTOBOTTOM|V_SNAPTOLEFT|V_ALLOWLOWERCASE, chat_log[i]); // get the current message, and word wrap it.
+		char *msg = CHAT_WordWrap(x+2, boxw-(charwidth*2), V_SNAPTOBOTTOM|V_SNAPTOLEFT|V_ALLOWLOWERCASE, chat_log[i]); // get the current message, and word wrap it.
 		UINT8 *colormap = NULL;
 		while(msg[j]) // iterate through msg
 		{
@@ -1586,6 +1586,7 @@ static void HU_drawChatLog(INT32 offset)
 		}
 		dy += charheight;
 		dx = 0;
+		Z_Free(msg);
 	}
 
 

--- a/src/m_aatree.c
+++ b/src/m_aatree.c
@@ -20,7 +20,6 @@
 
 typedef struct aatree_node_s
 {
-	INT32	level;
 	INT32	key;
 	void*	value;
 
@@ -109,9 +108,7 @@ static aatree_node_t *M_AATreeSet_Node(aatree_node_t *node, UINT32 flags, INT32 
 	if (!node)
 	{
 		// Nothing here, so just add where we are
-
 		node = Z_Malloc(sizeof (aatree_node_t), PU_STATIC, NULL);
-		node->level = 1;
 		node->key = key;
 		if (value && (flags & AATREE_ZUSER)) Z_SetUser(value, &node->value);
 		else node->value = value;
@@ -161,7 +158,6 @@ void *M_AATreeGet(aatree_t *aatree, INT32 key)
 {
 	return M_AATreeGet_Node(aatree->root, key);
 }
-
 
 static void M_AATreeIterate_Node(aatree_node_t *node, aatree_iter_t callback)
 {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -529,7 +529,7 @@ void M_FirstLoadConfig(void)
 void M_SaveConfig(const char *filename)
 {
 	FILE *f;
-	char *filepath;
+	const char *filepath;
 
 	// make sure not to write back the config until it's been correctly loaded
 	if (!gameconfig_loaded)
@@ -549,7 +549,7 @@ void M_SaveConfig(const char *filename)
 		if (!strstr(filename, srb2home))
 			filepath = va(pandf,srb2home, filename);
 		else
-			filepath = Z_StrDup(filename);
+			filepath = filename;
 
 		f = fopen(filepath, "w");
 		// change it only if valid

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -747,7 +747,15 @@ static void Command_Memdump_f(void)
   * \param s The string to be copied.
   * \return A copy of the string, allocated in zone memory.
   */
+#ifdef ZDEBUG
+char *Z_StrDup2(const char *s, const char *file, INT32 line)
+#else
 char *Z_StrDup(const char *s)
+#endif
 {
+#ifdef ZDEBUG
+	return strcpy(Z_Malloc2(strlen(s) + 1, PU_STATIC, NULL, 0, file, line), s);
+#else
 	return strcpy(ZZ_Alloc(strlen(s) + 1), s);
+#endif
 }

--- a/src/z_zone.h
+++ b/src/z_zone.h
@@ -143,7 +143,12 @@ size_t Z_TagsUsage(INT32 lowtag, INT32 hightag);
 //
 // Miscellaneous functions
 //
-char *Z_StrDup(const char *in);
+#ifdef ZDEBUG
+#define Z_StrDup(s) Z_StrDup2(s, __FILE__, __LINE__)
+char *Z_StrDup2(const char *s, const char *file, INT32 line);
+#else
+char *Z_StrDup(const char *s);
+#endif
 #define Z_Unlock(p) (void)p // TODO: remove this now that NDS code has been removed
 
 #endif


### PR DESCRIPTION
This hopefully fixes the final leaks in the engine, and most importantly the serious memory leak that causes memory use to skyrocket in OpenGL. Now, memory use remains on a steady 230 MB on Subarashii.

The cause was due to the chat log not deallocating it's string that it uses for each line, which massively wastes memory as it's being allocated multiple time for each frame. There was also another leak when saving configuration that was also fixed in the process.