### PR TITLE
Add the color cube 

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -707,8 +707,29 @@ void D_RegisterClientCommands(void)
 	COM_AddCommand("displayplayer", Command_Displayplayer_f);
 
 	// FIXME: not to be here.. but needs be done for config loading
-	CV_RegisterVar(&cv_usegamma);
-	CV_RegisterVar(&cv_usesaturation);
+	CV_RegisterVar(&cv_globalgamma);
+	CV_RegisterVar(&cv_globalsaturation);
+
+	CV_RegisterVar(&cv_rhue);
+	CV_RegisterVar(&cv_yhue);
+	CV_RegisterVar(&cv_ghue);
+	CV_RegisterVar(&cv_chue);
+	CV_RegisterVar(&cv_bhue);
+	CV_RegisterVar(&cv_mhue);
+
+	CV_RegisterVar(&cv_rgamma);
+	CV_RegisterVar(&cv_ygamma);
+	CV_RegisterVar(&cv_ggamma);
+	CV_RegisterVar(&cv_cgamma);
+	CV_RegisterVar(&cv_bgamma);
+	CV_RegisterVar(&cv_mgamma);
+
+	CV_RegisterVar(&cv_rsaturation);
+	CV_RegisterVar(&cv_ysaturation);
+	CV_RegisterVar(&cv_gsaturation);
+	CV_RegisterVar(&cv_csaturation);
+	CV_RegisterVar(&cv_bsaturation);
+	CV_RegisterVar(&cv_msaturation);
 
 	// m_menu.c
 	CV_RegisterVar(&cv_compactscoreboard);

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -708,6 +708,7 @@ void D_RegisterClientCommands(void)
 
 	// FIXME: not to be here.. but needs be done for config loading
 	CV_RegisterVar(&cv_usegamma);
+	CV_RegisterVar(&cv_usesaturation);
 
 	// m_menu.c
 	CV_RegisterVar(&cv_compactscoreboard);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -264,7 +264,7 @@ static void M_AssignJoystick(INT32 choice);
 static void M_ChangeControl(INT32 choice);
 
 // Video & Sound
-menu_t OP_VideoOptionsDef, OP_VideoModeDef;
+menu_t OP_VideoOptionsDef, OP_VideoModeDef, OP_ColorOptionsDef;
 #ifdef HWRENDER
 menu_t OP_OpenGLOptionsDef, OP_OpenGLColorDef, OP_OpenGLLightingDef;
 #endif
@@ -305,6 +305,7 @@ static void M_DrawNightsAttackMenu(void);
 static void M_DrawSetupChoosePlayerMenu(void);
 static void M_DrawControl(void);
 static void M_DrawVideoMode(void);
+static void M_DrawColorMenu(void);
 static void M_DrawMonitorToggles(void);
 #ifdef HWRENDER
 static void M_OGL_DrawColorMenu(void);
@@ -334,6 +335,8 @@ static void M_HandleConnectIP(INT32 choice);
 #endif
 static void M_HandleSetupMultiPlayer(INT32 choice);
 static void M_HandleVideoMode(INT32 choice);
+
+static void M_ResetCvars(void);
 
 // Consvar onchange functions
 static void Nextmap_OnChange(void);
@@ -1148,20 +1151,64 @@ static menuitem_t OP_VideoOptionsMenu[] =
 #endif
 
 	{IT_STRING | IT_CVAR | IT_CV_SLIDER,
-	                         NULL, "Brightness",          &cv_usegamma,      50},
+	                         NULL, "Brightness",          &cv_globalgamma,      50},
 	{IT_STRING | IT_CVAR | IT_CV_SLIDER,
-							 NULL, "Saturation",      &cv_usesaturation,     60},   
-	{IT_STRING | IT_CVAR,    NULL, "Draw Distance",       &cv_drawdist, 70},
-	{IT_STRING | IT_CVAR,    NULL, "NiGHTS Draw Dist",    &cv_drawdist_nights, 80},
-	{IT_STRING | IT_CVAR,    NULL, "Precip Draw Dist",    &cv_drawdist_precip, 90},
-	{IT_STRING | IT_CVAR,    NULL, "Precip Density",      &cv_precipdensity, 100},
+							 NULL, "Saturation",          &cv_globalsaturation, 60},   
+    {IT_SUBMENU|IT_STRING, NULL, "Advanced Color Settings...", &OP_ColorOptionsDef, 70},
+	{IT_STRING | IT_CVAR,    NULL, "Draw Distance",       &cv_drawdist, 80},
+	{IT_STRING | IT_CVAR,    NULL, "NiGHTS Draw Dist",    &cv_drawdist_nights, 90},
+	{IT_STRING | IT_CVAR,    NULL, "Precip Draw Dist",    &cv_drawdist_precip, 100},
+	{IT_STRING | IT_CVAR,    NULL, "Precip Density",      &cv_precipdensity, 110},
 
-	{IT_STRING | IT_CVAR,    NULL, "Show FPS",            &cv_ticrate,    110},
-	{IT_STRING | IT_CVAR,    NULL, "Show TPS",            &cv_tpscounter,    120},
-	{IT_STRING | IT_CVAR,    NULL, "Clear Before Redraw", &cv_homremoval, 130},
-	{IT_STRING | IT_CVAR,    NULL, "Vertical Sync",       &cv_vidwait,    140},
-	{IT_STRING | IT_CVAR,    NULL, "FPS Cap",       &cv_fpscap, 150},
+	{IT_STRING | IT_CVAR,    NULL, "Show FPS",            &cv_ticrate,    120},
+	{IT_STRING | IT_CVAR,    NULL, "Show TPS",            &cv_tpscounter,    130},
+	{IT_STRING | IT_CVAR,    NULL, "Clear Before Redraw", &cv_homremoval, 140},
+	{IT_STRING | IT_CVAR,    NULL, "Vertical Sync",       &cv_vidwait,    150},
+	{IT_STRING | IT_CVAR,    NULL, "FPS Cap",       &cv_fpscap, 160},
 };
+
+static menuitem_t OP_ColorOptionsMenu[] =
+{
+	{IT_STRING | IT_CALL, NULL, "Reset all", M_ResetCvars, 0},
+
+	{IT_HEADER, NULL, "Red", NULL, 9},
+	{IT_DISABLED, NULL, NULL, NULL, 35},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Hue",          &cv_rhue,         15},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Saturation",   &cv_rsaturation,  20},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Brightness",   &cv_rgamma,       25},
+
+	{IT_HEADER, NULL, "Yellow", NULL, 34},
+	{IT_DISABLED, NULL, NULL, NULL, 73},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Hue",          &cv_yhue,         40},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Saturation",   &cv_ysaturation,  45},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Brightness",   &cv_ygamma,       50},
+
+	{IT_HEADER, NULL, "Green", NULL, 59},
+	{IT_DISABLED, NULL, NULL, NULL, 112},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Hue",          &cv_ghue,         65},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Saturation",   &cv_gsaturation,  70},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Brightness",   &cv_ggamma,       75},
+
+	{IT_HEADER, NULL, "Cyan", NULL, 84},
+	{IT_DISABLED, NULL, NULL, NULL, 255},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Hue",          &cv_chue,         90},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Saturation",   &cv_csaturation,  95},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Brightness",   &cv_cgamma,      100},
+
+	{IT_HEADER, NULL, "Blue", NULL, 109},
+	{IT_DISABLED, NULL, NULL, NULL, 152},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Hue",          &cv_bhue,        115},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Saturation",   &cv_bsaturation, 120},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Brightness",   &cv_bgamma,      125},
+
+	{IT_HEADER, NULL, "Magenta", NULL, 134},
+	{IT_DISABLED, NULL, NULL, NULL, 181},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Hue",          &cv_mhue,        140},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Saturation",   &cv_msaturation, 145},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, NULL, "Brightness",   &cv_mgamma,      150},
+};
+
+
 
 static menuitem_t OP_VideoModeMenu[] =
 {
@@ -1757,6 +1804,17 @@ menu_t OP_VideoModeDef =
 	0,
 	NULL
 };
+menu_t OP_ColorOptionsDef =
+{
+	"M_VIDEO",
+	sizeof (OP_ColorOptionsMenu)/sizeof (menuitem_t),
+	&OP_VideoOptionsDef,
+	OP_ColorOptionsMenu,
+	M_DrawColorMenu,
+	30, 30,
+	0,
+	NULL
+};
 menu_t OP_SoundOptionsDef = DEFAULTMENUSTYLE("M_SOUND", OP_SoundOptionsMenu, &OP_MainDef, 60, 30);
 menu_t OP_SoundAdvancedDef = DEFAULTMENUSTYLE("M_SOUND", OP_SoundAdvancedMenu, &OP_SoundOptionsDef, 30, 30);
 menu_t OP_GameOptionsDef = DEFAULTMENUSTYLE("M_GAME", OP_GameOptionsMenu, &OP_MainDef, 30, 30);
@@ -2105,6 +2163,19 @@ static boolean M_ChangeStringCvar(INT32 choice)
 			break;
 	}
 	return false;
+}
+
+// resets all cvars on a menu - assumes that all that have itemactions are cvars
+static void M_ResetCvars(void)
+{
+	INT32 i;
+	consvar_t *cv;
+	for (i = 0; i < currentMenu->numitems; i++)
+	{
+		if (!(currentMenu->menuitems[i].status & IT_CVAR) || !(cv = (consvar_t *)currentMenu->menuitems[i].itemaction))
+			continue;
+		CV_SetValue(cv, atoi(cv->defaultvalue));
+	}
 }
 
 static void M_NextOpt(void)
@@ -7787,13 +7858,13 @@ static void M_DrawGenericScrollMenu(void)
 
 	for (i = 0; i < currentMenu->numitems; i++)
 	{
-		if (currentMenu->menuitems[i].alphaKey*2 + tempcentery >= currentMenu->y)
+		if (currentMenu->menuitems[i].status != IT_DISABLED && currentMenu->menuitems[i].alphaKey*2 + tempcentery >= currentMenu->y)
 			break;
 	}
 
 	for (max = currentMenu->numitems; max > 0; max--)
 	{
-		if (currentMenu->menuitems[max-1].alphaKey*2 + tempcentery <= (currentMenu->y + 2*scrollareaheight))
+		if (currentMenu->menuitems[max-1].status != IT_DISABLED && currentMenu->menuitems[max-1].alphaKey*2 + tempcentery <= (currentMenu->y + 2*scrollareaheight))
 			break;
 	}
 
@@ -7878,10 +7949,6 @@ static void M_DrawGenericScrollMenu(void)
 		W_CachePatchName("M_CURSOR", PU_CACHE));
 }
 
-#undef scrollareaheight
-
-
-#undef controlheight
 
 static INT32 controltochange;
 static char controltochangetext[33];
@@ -8154,6 +8221,120 @@ static void M_DrawVideoMode(void)
 	V_DrawScaledPatch(i - 8, j, 0,
 		W_CachePatchName("M_CURSOR", PU_CACHE));
 }
+
+// Just M_DrawGenericScrollMenu but showing a backing behind the headers.
+static void M_DrawColorMenu(void)
+{
+	INT32 x, y, i, max, tempcentery, cursory = 0;
+
+	// DRAW MENU
+	x = currentMenu->x;
+	y = currentMenu->y;
+
+	if ((currentMenu->menuitems[itemOn].alphaKey*2 - currentMenu->menuitems[0].alphaKey*2) <= scrollareaheight)
+		tempcentery = currentMenu->y - currentMenu->menuitems[0].alphaKey*2;
+	else if ((currentMenu->menuitems[currentMenu->numitems-1].alphaKey*2 - currentMenu->menuitems[itemOn].alphaKey*2) <= scrollareaheight)
+		tempcentery = currentMenu->y - currentMenu->menuitems[currentMenu->numitems-1].alphaKey*2 + 2*scrollareaheight;
+	else
+		tempcentery = currentMenu->y - currentMenu->menuitems[itemOn].alphaKey*2 + scrollareaheight;
+
+	for (i = 0; i < currentMenu->numitems; i++)
+	{
+		if (currentMenu->menuitems[i].status != IT_DISABLED && currentMenu->menuitems[i].alphaKey*2 + tempcentery >= currentMenu->y)
+			break;
+	}
+
+	for (max = currentMenu->numitems; max > 0; max--)
+	{
+		if (currentMenu->menuitems[max].status != IT_DISABLED && currentMenu->menuitems[max-1].alphaKey*2 + tempcentery <= (currentMenu->y + 2*scrollareaheight))
+			break;
+	}
+
+	if (i)
+		V_DrawCharacter(currentMenu->x - 16, y - (skullAnimCounter / 5),
+			'\x1A' |V_YELLOWMAP, false); // up arrow
+	if (max != currentMenu->numitems)
+		V_DrawCharacter(currentMenu->x - 16, y + (SMALLLINEHEIGHT * (controlheight - 1)) + (skullAnimCounter / 5) + (skullAnimCounter / 5),
+			'\x1B' |V_YELLOWMAP, false); // down arrowow
+
+	// draw title (or big pic)
+	M_DrawMenuTitle();
+
+	for (; i < max; i++)
+	{
+		y = currentMenu->menuitems[i].alphaKey*2 + tempcentery;
+		if (i == itemOn)
+			cursory = y;
+		switch (currentMenu->menuitems[i].status & IT_DISPLAY)
+		{
+			case IT_PATCH:
+			case IT_DYBIGSPACE:
+			case IT_BIGSLIDER:
+			case IT_STRING2:
+			case IT_DYLITLSPACE:
+			case IT_GRAYPATCH:
+			case IT_TRANSTEXT2:
+				// unsupported
+				break;
+			case IT_NOTHING:
+				break;
+			case IT_STRING:
+			case IT_WHITESTRING:
+				if (i != itemOn && (currentMenu->menuitems[i].status & IT_DISPLAY)==IT_STRING)
+					V_DrawString(x, y, 0, currentMenu->menuitems[i].text);
+				else
+					V_DrawString(x, y, V_YELLOWMAP, currentMenu->menuitems[i].text);
+
+				// Cvar specific handling
+				switch (currentMenu->menuitems[i].status & IT_TYPE)
+					case IT_CVAR:
+					{
+						consvar_t *cv = (consvar_t *)currentMenu->menuitems[i].itemaction;
+						switch (currentMenu->menuitems[i].status & IT_CVARTYPE)
+						{
+							case IT_CV_SLIDER:
+								M_DrawSlider(x, y, cv);
+							case IT_CV_NOPRINT: // color use this
+							case IT_CV_INVISSLIDER: // monitor toggles use this
+								break;
+							case IT_CV_STRING:
+								if (y + 12 > (currentMenu->y + 2*scrollareaheight))
+									break;
+								M_DrawTextBox(x, y + 4, MAXSTRINGLENGTH, 1);
+								V_DrawString(x + 8, y + 12, V_ALLOWLOWERCASE, cv->string);
+								if (skullAnimCounter < 4 && i == itemOn)
+									V_DrawCharacter(x + 8 + V_StringWidth(cv->string, 0), y + 12,
+										'_' | 0x80, false);
+								y += 16;
+								break;
+							default:
+								V_DrawRightAlignedString(BASEVIDWIDTH - x, y,
+									((cv->flags & CV_CHEAT) && !CV_IsSetToDefault(cv) ? V_REDMAP : V_YELLOWMAP), cv->string);
+								break;
+						}
+						break;
+					}
+					break;
+			case IT_TRANSTEXT:
+				V_DrawString(x, y, V_TRANSLUCENT, currentMenu->menuitems[i].text);
+				break;
+			case IT_QUESTIONMARKS:
+				V_DrawString(x, y, V_TRANSLUCENT|V_OLDSPACING, M_CreateSecretMenuOption(currentMenu->menuitems[i].text));
+				break;
+			case IT_HEADERTEXT:
+				V_DrawString(x-16, y, V_YELLOWMAP, currentMenu->menuitems[i].text);
+				//V_DrawFill(19, y, 281, 9, currentMenu->menuitems[i+1].alphaKey);
+				//V_DrawFill(300, y, 1, 9, 26);
+				//M_DrawLevelPlatterHeader(y - (lsheadingheight - 12), currentMenu->menuitems[i].text, false);
+				break;
+		}
+	}
+
+	// DRAW THE SKULL CURSOR
+	V_DrawScaledPatch(currentMenu->x - 24, cursory, 0,
+		W_CachePatchName("M_CURSOR", PU_CACHE));
+}
+
 
 // special menuitem key handler for video mode list
 static void M_HandleVideoMode(INT32 ch)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1149,16 +1149,18 @@ static menuitem_t OP_VideoOptionsMenu[] =
 
 	{IT_STRING | IT_CVAR | IT_CV_SLIDER,
 	                         NULL, "Brightness",          &cv_usegamma,      50},
-	{IT_STRING | IT_CVAR,    NULL, "Draw Distance",       &cv_drawdist, 60},
-	{IT_STRING | IT_CVAR,    NULL, "NiGHTS Draw Dist",    &cv_drawdist_nights, 70},
-	{IT_STRING | IT_CVAR,    NULL, "Precip Draw Dist",    &cv_drawdist_precip, 80},
-	{IT_STRING | IT_CVAR,    NULL, "Precip Density",      &cv_precipdensity, 90},
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER,
+							 NULL, "Saturation",      &cv_usesaturation,     60},   
+	{IT_STRING | IT_CVAR,    NULL, "Draw Distance",       &cv_drawdist, 70},
+	{IT_STRING | IT_CVAR,    NULL, "NiGHTS Draw Dist",    &cv_drawdist_nights, 80},
+	{IT_STRING | IT_CVAR,    NULL, "Precip Draw Dist",    &cv_drawdist_precip, 90},
+	{IT_STRING | IT_CVAR,    NULL, "Precip Density",      &cv_precipdensity, 100},
 
-	{IT_STRING | IT_CVAR,    NULL, "Show FPS",            &cv_ticrate,    100},
-	{IT_STRING | IT_CVAR,    NULL, "Show TPS",            &cv_tpscounter,    110},
-	{IT_STRING | IT_CVAR,    NULL, "Clear Before Redraw", &cv_homremoval, 120},
-	{IT_STRING | IT_CVAR,    NULL, "Vertical Sync",       &cv_vidwait,    130},
-	{IT_STRING | IT_CVAR,    NULL, "FPS Cap",       &cv_fpscap, 140},
+	{IT_STRING | IT_CVAR,    NULL, "Show FPS",            &cv_ticrate,    110},
+	{IT_STRING | IT_CVAR,    NULL, "Show TPS",            &cv_tpscounter,    120},
+	{IT_STRING | IT_CVAR,    NULL, "Clear Before Redraw", &cv_homremoval, 130},
+	{IT_STRING | IT_CVAR,    NULL, "Vertical Sync",       &cv_vidwait,    140},
+	{IT_STRING | IT_CVAR,    NULL, "FPS Cap",       &cv_fpscap, 150},
 };
 
 static menuitem_t OP_VideoModeMenu[] =

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -38,17 +38,45 @@ UINT8 *screens[5];
 // screens[3] = fade screen start
 // screens[4] = fade screen end, postimage tempoarary buffer
 
-static CV_PossibleValue_t gamma_cons_t[] = {{-5, "MIN"}, {5, "MAX"}, {0, NULL}};
-static void CV_usegamma_OnChange(void);
+
 
 static CV_PossibleValue_t ticrate_cons_t[] = { {0, "No"}, {1, "Full"}, {2, "Compact"}, {0, NULL} };
 static CV_PossibleValue_t tpscounter_cons_t[] = { {0, "No"}, {1, "Full"}, {2, "Compact"}, {0, NULL} };
 consvar_t cv_ticrate = { "showfps", "No", CV_SAVE, ticrate_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL };
 consvar_t cv_tpscounter = { "showtps", "No", CV_SAVE, tpscounter_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL };
-consvar_t cv_usegamma = {"gamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_usegamma_OnChange, 0, NULL, NULL, 0, 0, NULL};
+
+static void CV_palette_OnChange(void);
+
+static CV_PossibleValue_t gamma_cons_t[] = {{-15, "MIN"}, {5, "MAX"}, {0, NULL}};
+consvar_t cv_globalgamma = {"gamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
 
 static CV_PossibleValue_t saturation_cons_t[] = {{0, "MIN"}, {10, "MAX"}, {0, NULL}};
-consvar_t cv_usesaturation = {"saturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_usegamma_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_globalsaturation = {"saturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+
+#define huecoloursteps 4
+
+static CV_PossibleValue_t hue_cons_t[] = {{0, "MIN"}, {(huecoloursteps*6)-1, "MAX"}, {0, NULL}};
+consvar_t cv_rhue = {"rhue",  "0", CV_SAVE|CV_CALL, hue_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_yhue = {"yhue",  "4", CV_SAVE|CV_CALL, hue_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_ghue = {"ghue",  "8", CV_SAVE|CV_CALL, hue_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_chue = {"chue", "12", CV_SAVE|CV_CALL, hue_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_bhue = {"bhue", "16", CV_SAVE|CV_CALL, hue_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_mhue = {"mhue", "20", CV_SAVE|CV_CALL, hue_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+
+consvar_t cv_rgamma = {"rgamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_ygamma = {"ygamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_ggamma = {"ggamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_cgamma = {"cgamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_bgamma = {"bgamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_mgamma = {"mgamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+
+consvar_t cv_rsaturation = {"rsaturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_ysaturation = {"ysaturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_gsaturation = {"gsaturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_csaturation = {"csaturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_bsaturation = {"bsaturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_msaturation = {"msaturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_palette_OnChange, 0, NULL, NULL, 0, 0, NULL};
+
 
 consvar_t cv_allcaps = {"allcaps", "Off", 0, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
 
@@ -111,71 +139,153 @@ static boolean InitCube(void)
 		{
 			{
 				{0.0, 0.0, 0.0}, // black corner
-				{1.0, 0.0, 0.0}  // red corner
+				{0.0, 0.0, 1.0}  // blue corner
 			},
 			{
 				{0.0, 1.0, 0.0}, // green corner
-				{1.0, 1.0, 0.0}  // yellow corner
+				{0.0, 1.0, 1.0}  // cyan corner
 			}
 		},
 		{
 			{
-				{0.0, 0.0, 1.0}, // blue corner
+				{1.0, 0.0, 0.0}, // red corner
 				{1.0, 0.0, 1.0}  // magenta corner
 			},
 			{
-				{0.0, 1.0, 1.0}, // cyan corner
+				{1.0, 1.0, 0.0}, // yellow corner
 				{1.0, 1.0, 1.0}  // white corner
 			}
 		}
 	};
+	float desatur[3]; // grey
+	float globalgammamul, globalgammaoffs;
+	boolean doinggamma;
 
-	if (cv_usegamma.value)
-	{
+#define diffcons(cv) (cv.value != atoi(cv.defaultvalue))
+
+	doinggamma = diffcons(cv_globalgamma);
+
 #define gammascale 8
-		float gammamul = (255 - (gammascale*abs(cv_usegamma.value)))/255.0;
-		float gammaoffs = ((cv_usegamma.value > 0) ? ((gammascale*cv_usegamma.value)/255.0) : 0.0);
-#undef gammascale
+	globalgammamul = (cv_globalgamma.value ? ((255 - (gammascale*abs(cv_globalgamma.value)))/255.0) : 1.0);
+	globalgammaoffs = ((cv_globalgamma.value > 0) ? ((gammascale*cv_globalgamma.value)/255.0) : 0.0);
+	desatur[0] = desatur[1] = desatur[2] = globalgammaoffs + (0.33*globalgammamul);
 
-		apply = true;
-
-		#define dogamma(i, j, k, l) \
-			working[i][j][k][l]*= gammamul;\
-			working[i][j][k][l] += gammaoffs
-		for (q = 0; q < 3; q++)
-		{
-			dogamma(0, 0, 0, q);
-			dogamma(1, 0, 0, q);
-			dogamma(0, 1, 0, q);
-			dogamma(1, 1, 0, q);
-			dogamma(0, 0, 1, q);
-			dogamma(1, 0, 1, q);
-			dogamma(0, 1, 1, q);
-			dogamma(1, 1, 1, q);
-		}
-#undef dogamma
-	}
-
-	if (cv_usesaturation.value != 10)
+	if (doinggamma
+		|| diffcons(cv_rhue)
+		|| diffcons(cv_yhue)
+		|| diffcons(cv_ghue)
+		|| diffcons(cv_chue)
+		|| diffcons(cv_bhue)
+		|| diffcons(cv_mhue)
+		|| diffcons(cv_rgamma)
+		|| diffcons(cv_ygamma)
+		|| diffcons(cv_ggamma)
+		|| diffcons(cv_cgamma)
+		|| diffcons(cv_bgamma)
+		|| diffcons(cv_mgamma))
 	{
-		float desatur[3] = {0.33, 0.33, 0.33}; // grey
-		float work = (cv_usesaturation.value/10.0);
+		float mod, tempgammamul, tempgammaoffs;
 
 		apply = true;
+
+		working[0][0][0][0] = working[0][0][0][1] = working[0][0][0][2] = globalgammaoffs;
+		working[1][1][1][0] = working[1][1][1][1] = working[1][1][1][2] = globalgammaoffs+globalgammamul;
+
+#define dohue(hue, gamma, loc) \
+		tempgammamul = (gamma ? ((255 - (gammascale*abs(gamma)))/255.0)*globalgammamul : globalgammamul);\
+		tempgammaoffs = ((gamma > 0) ? ((gammascale*gamma)/255.0) + globalgammaoffs : globalgammaoffs);\
+		mod = ((hue % huecoloursteps)*(tempgammamul)/huecoloursteps);\
+		switch (hue/huecoloursteps)\
+		{\
+			case 0:\
+			default:\
+				loc[0] = tempgammaoffs+tempgammamul;\
+				loc[1] = tempgammaoffs+mod;\
+				loc[2] = tempgammaoffs;\
+				break;\
+			case 1:\
+				loc[0] = tempgammaoffs+tempgammamul-mod;\
+				loc[1] = tempgammaoffs+tempgammamul;\
+				loc[2] = tempgammaoffs;\
+				break;\
+			case 2:\
+				loc[0] = tempgammaoffs;\
+				loc[1] = tempgammaoffs+tempgammamul;\
+				loc[2] = tempgammaoffs+mod;\
+				break;\
+			case 3:\
+				loc[0] = tempgammaoffs;\
+				loc[1] = tempgammaoffs+tempgammamul-mod;\
+				loc[2] = tempgammaoffs+tempgammamul;\
+				break;\
+			case 4:\
+				loc[0] = tempgammaoffs+mod;\
+				loc[1] = tempgammaoffs;\
+				loc[2] = tempgammaoffs+tempgammamul;\
+				break;\
+			case 5:\
+				loc[0] = tempgammaoffs+tempgammamul;\
+				loc[1] = tempgammaoffs;\
+				loc[2] = tempgammaoffs+tempgammamul-mod;\
+				break;\
+		}
+		dohue(cv_rhue.value, cv_rgamma.value, working[1][0][0]);
+		dohue(cv_yhue.value, cv_ygamma.value, working[1][1][0]);
+		dohue(cv_ghue.value, cv_ggamma.value, working[0][1][0]);
+		dohue(cv_chue.value, cv_cgamma.value, working[0][1][1]);
+		dohue(cv_bhue.value, cv_bgamma.value, working[0][0][1]);
+		dohue(cv_mhue.value, cv_mgamma.value, working[1][0][1]);
+#undef dohue
+	}
 
 #define dosaturation(a, e) a = ((1 - work)*e + work*a)
+#define docvsat(cv_sat, hue, gamma, r, g, b) \
+	if diffcons(cv_sat)\
+	{\
+		float work, mod, tempgammamul, tempgammaoffs;\
+		apply = true;\
+		work = (cv_sat.value/10.0);\
+		mod = ((hue % huecoloursteps)*(1.0)/huecoloursteps);\
+		if (hue & huecoloursteps)\
+			mod = 2-mod;\
+		else\
+			mod += 1;\
+		tempgammamul = (gamma ? ((255 - (gammascale*abs(gamma)))/255.0)*globalgammamul : globalgammamul);\
+		tempgammaoffs = ((gamma > 0) ? ((gammascale*gamma)/255.0) + globalgammaoffs : globalgammaoffs);\
+		for (q = 0; q < 3; q++)\
+			dosaturation(working[r][g][b][q], (tempgammaoffs+(desatur[q]*mod*tempgammamul)));\
+	}
+
+	docvsat(cv_rsaturation, cv_rhue.value, cv_rgamma.value, 1, 0, 0);
+	docvsat(cv_ysaturation, cv_yhue.value, cv_ygamma.value, 1, 1, 0);
+	docvsat(cv_gsaturation, cv_ghue.value, cv_ggamma.value, 0, 1, 0);
+	docvsat(cv_csaturation, cv_chue.value, cv_cgamma.value, 0, 1, 1);
+	docvsat(cv_bsaturation, cv_bhue.value, cv_bgamma.value, 0, 0, 1);
+	docvsat(cv_msaturation, cv_mhue.value, cv_mgamma.value, 1, 0, 1);
+
+#undef gammascale
+
+	if diffcons(cv_globalsaturation)
+	{
+		float work = (cv_globalsaturation.value/10.0);
+
+		apply = true;
+
 		for (q = 0; q < 3; q++)
 		{
-			dosaturation(working[0][0][1][q], desatur[q]);
-			dosaturation(working[0][1][0][q], desatur[q]);
 			dosaturation(working[1][0][0][q], desatur[q]);
+			dosaturation(working[0][1][0][q], desatur[q]);
+			dosaturation(working[0][0][1][q], desatur[q]);
 
 			dosaturation(working[1][1][0][q], 2*desatur[q]);
-			dosaturation(working[1][0][1][q], 2*desatur[q]);
 			dosaturation(working[0][1][1][q], 2*desatur[q]);
+			dosaturation(working[1][0][1][q], 2*desatur[q]);
 		}
-#undef dosaturation
 	}
+
+#undef dosaturation
+
+#undef diffcons
 
 	if (!apply)
 		return false;
@@ -329,7 +439,7 @@ void V_SetPaletteLump(const char *pal)
 		I_SetPalette(pLocalPalette);
 }
 
-static void CV_usegamma_OnChange(void)
+static void CV_palette_OnChange(void)
 {
 	// reload palette
 	LoadMapPalette();

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -38,7 +38,7 @@ UINT8 *screens[5];
 // screens[3] = fade screen start
 // screens[4] = fade screen end, postimage tempoarary buffer
 
-static CV_PossibleValue_t gamma_cons_t[] = {{0, "MIN"}, {4, "MAX"}, {0, NULL}};
+static CV_PossibleValue_t gamma_cons_t[] = {{-5, "MIN"}, {5, "MAX"}, {0, NULL}};
 static void CV_usegamma_OnChange(void);
 
 static CV_PossibleValue_t ticrate_cons_t[] = { {0, "No"}, {1, "Full"}, {2, "Compact"}, {0, NULL} };
@@ -46,6 +46,9 @@ static CV_PossibleValue_t tpscounter_cons_t[] = { {0, "No"}, {1, "Full"}, {2, "C
 consvar_t cv_ticrate = { "showfps", "No", CV_SAVE, ticrate_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL };
 consvar_t cv_tpscounter = { "showtps", "No", CV_SAVE, tpscounter_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL };
 consvar_t cv_usegamma = {"gamma", "0", CV_SAVE|CV_CALL, gamma_cons_t, CV_usegamma_OnChange, 0, NULL, NULL, 0, 0, NULL};
+
+static CV_PossibleValue_t saturation_cons_t[] = {{0, "MIN"}, {10, "MAX"}, {0, NULL}};
+consvar_t cv_usesaturation = {"saturation", "10", CV_SAVE|CV_CALL, saturation_cons_t, CV_usegamma_OnChange, 0, NULL, NULL, 0, 0, NULL};
 
 consvar_t cv_allcaps = {"allcaps", "Off", 0, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
 
@@ -84,97 +87,127 @@ consvar_t cv_grspritebillboarding = {"gr_spritebillboarding", "Off", CV_SAVE, CV
 consvar_t cv_grskydome = {"gr_skydome", "Off", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL}; //now off by default
 #endif
 
-const UINT8 gammatable[5][256] =
-{
-	{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,
-	17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,
-	33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,
-	49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,
-	65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,
-	81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,
-	97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,
-	113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,
-	128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,
-	144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,
-	160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,
-	176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,
-	192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,
-	208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,
-	224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,
-	240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255},
 
-	{2,4,5,7,8,10,11,12,14,15,16,18,19,20,21,23,24,25,26,27,29,30,31,
-	32,33,34,36,37,38,39,40,41,42,44,45,46,47,48,49,50,51,52,54,55,
-	56,57,58,59,60,61,62,63,64,65,66,67,69,70,71,72,73,74,75,76,77,
-	78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,
-	99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,
-	115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,129,
-	130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,
-	146,147,148,148,149,150,151,152,153,154,155,156,157,158,159,160,
-	161,162,163,163,164,165,166,167,168,169,170,171,172,173,174,175,
-	175,176,177,178,179,180,181,182,183,184,185,186,186,187,188,189,
-	190,191,192,193,194,195,196,196,197,198,199,200,201,202,203,204,
-	205,205,206,207,208,209,210,211,212,213,214,214,215,216,217,218,
-	219,220,221,222,222,223,224,225,226,227,228,229,230,230,231,232,
-	233,234,235,236,237,237,238,239,240,241,242,243,244,245,245,246,
-	247,248,249,250,251,252,252,253,254,255},
-
-	{4,7,9,11,13,15,17,19,21,22,24,26,27,29,30,32,33,35,36,38,39,40,42,
-	43,45,46,47,48,50,51,52,54,55,56,57,59,60,61,62,63,65,66,67,68,69,
-	70,72,73,74,75,76,77,78,79,80,82,83,84,85,86,87,88,89,90,91,92,93,
-	94,95,96,97,98,100,101,102,103,104,105,106,107,108,109,110,111,112,
-	113,114,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,
-	129,130,131,132,133,133,134,135,136,137,138,139,140,141,142,143,144,
-	144,145,146,147,148,149,150,151,152,153,153,154,155,156,157,158,159,
-	160,160,161,162,163,164,165,166,166,167,168,169,170,171,172,172,173,
-	174,175,176,177,178,178,179,180,181,182,183,183,184,185,186,187,188,
-	188,189,190,191,192,193,193,194,195,196,197,197,198,199,200,201,201,
-	202,203,204,205,206,206,207,208,209,210,210,211,212,213,213,214,215,
-	216,217,217,218,219,220,221,221,222,223,224,224,225,226,227,228,228,
-	229,230,231,231,232,233,234,235,235,236,237,238,238,239,240,241,241,
-	242,243,244,244,245,246,247,247,248,249,250,251,251,252,253,254,254,
-	255},
-
-	{8,12,16,19,22,24,27,29,31,34,36,38,40,41,43,45,47,49,50,52,53,55,
-	57,58,60,61,63,64,65,67,68,70,71,72,74,75,76,77,79,80,81,82,84,85,
-	86,87,88,90,91,92,93,94,95,96,98,99,100,101,102,103,104,105,106,107,
-	108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,
-	125,126,127,128,129,130,131,132,133,134,135,135,136,137,138,139,140,
-	141,142,143,143,144,145,146,147,148,149,150,150,151,152,153,154,155,
-	155,156,157,158,159,160,160,161,162,163,164,165,165,166,167,168,169,
-	169,170,171,172,173,173,174,175,176,176,177,178,179,180,180,181,182,
-	183,183,184,185,186,186,187,188,189,189,190,191,192,192,193,194,195,
-	195,196,197,197,198,199,200,200,201,202,202,203,204,205,205,206,207,
-	207,208,209,210,210,211,212,212,213,214,214,215,216,216,217,218,219,
-	219,220,221,221,222,223,223,224,225,225,226,227,227,228,229,229,230,
-	231,231,232,233,233,234,235,235,236,237,237,238,238,239,240,240,241,
-	242,242,243,244,244,245,246,246,247,247,248,249,249,250,251,251,252,
-	253,253,254,254,255},
-
-	{16,23,28,32,36,39,42,45,48,50,53,55,57,60,62,64,66,68,69,71,73,75,76,
-	78,80,81,83,84,86,87,89,90,92,93,94,96,97,98,100,101,102,103,105,106,
-	107,108,109,110,112,113,114,115,116,117,118,119,120,121,122,123,124,
-	125,126,128,128,129,130,131,132,133,134,135,136,137,138,139,140,141,
-	142,143,143,144,145,146,147,148,149,150,150,151,152,153,154,155,155,
-	156,157,158,159,159,160,161,162,163,163,164,165,166,166,167,168,169,
-	169,170,171,172,172,173,174,175,175,176,177,177,178,179,180,180,181,
-	182,182,183,184,184,185,186,187,187,188,189,189,190,191,191,192,193,
-	193,194,195,195,196,196,197,198,198,199,200,200,201,202,202,203,203,
-	204,205,205,206,207,207,208,208,209,210,210,211,211,212,213,213,214,
-	214,215,216,216,217,217,218,219,219,220,220,221,221,222,223,223,224,
-	224,225,225,226,227,227,228,228,229,229,230,230,231,232,232,233,233,
-	234,234,235,235,236,236,237,237,238,239,239,240,240,241,241,242,242,
-	243,243,244,244,245,245,246,246,247,247,248,248,249,249,250,250,251,
-	251,252,252,253,254,254,255,255}
-};
 
 // local copy of the palette for V_GetColor()
 RGBA_t *pLocalPalette = NULL;
 
+/*
+The following was an extremely helpful resource when developing my Colour Cube LUT.
+http://http.developer.nvidia.com/GPUGems2/gpugems2_chapter24.html
+Please check it out if you're trying to maintain this.
+toast 18/04/17
+*/
+
+float Cubepal[2][2][2][3];
+
+// returns whether to apply cube, selectively avoiding expensive operations
+static boolean InitCube(void)
+{
+	boolean apply = false;
+	UINT8 q;
+	float working[2][2][2][3] = // the initial positions of the corners of the colour cube!
+	{
+		{
+			{
+				{0.0, 0.0, 0.0}, // black corner
+				{1.0, 0.0, 0.0}  // red corner
+			},
+			{
+				{0.0, 1.0, 0.0}, // green corner
+				{1.0, 1.0, 0.0}  // yellow corner
+			}
+		},
+		{
+			{
+				{0.0, 0.0, 1.0}, // blue corner
+				{1.0, 0.0, 1.0}  // magenta corner
+			},
+			{
+				{0.0, 1.0, 1.0}, // cyan corner
+				{1.0, 1.0, 1.0}  // white corner
+			}
+		}
+	};
+
+	if (cv_usegamma.value)
+	{
+#define gammascale 8
+		float gammamul = (255 - (gammascale*abs(cv_usegamma.value)))/255.0;
+		float gammaoffs = ((cv_usegamma.value > 0) ? ((gammascale*cv_usegamma.value)/255.0) : 0.0);
+#undef gammascale
+
+		apply = true;
+
+		#define dogamma(i, j, k, l) \
+			working[i][j][k][l]*= gammamul;\
+			working[i][j][k][l] += gammaoffs
+		for (q = 0; q < 3; q++)
+		{
+			dogamma(0, 0, 0, q);
+			dogamma(1, 0, 0, q);
+			dogamma(0, 1, 0, q);
+			dogamma(1, 1, 0, q);
+			dogamma(0, 0, 1, q);
+			dogamma(1, 0, 1, q);
+			dogamma(0, 1, 1, q);
+			dogamma(1, 1, 1, q);
+		}
+#undef dogamma
+	}
+
+	if (cv_usesaturation.value != 10)
+	{
+		float desatur[3] = {0.33, 0.33, 0.33}; // grey
+		float work = (cv_usesaturation.value/10.0);
+
+		apply = true;
+
+#define dosaturation(a, e) a = ((1 - work)*e + work*a)
+		for (q = 0; q < 3; q++)
+		{
+			dosaturation(working[0][0][1][q], desatur[q]);
+			dosaturation(working[0][1][0][q], desatur[q]);
+			dosaturation(working[1][0][0][q], desatur[q]);
+
+			dosaturation(working[1][1][0][q], 2*desatur[q]);
+			dosaturation(working[1][0][1][q], 2*desatur[q]);
+			dosaturation(working[0][1][1][q], 2*desatur[q]);
+		}
+#undef dosaturation
+	}
+
+	if (!apply)
+		return false;
+
+#define dowork(i, j, k, l) \
+	if (working[i][j][k][l] > 1.0)\
+		working[i][j][k][l] = 1.0;\
+	else if (working[i][j][k][l] < 0.0)\
+		working[i][j][k][l] = 0.0;\
+	Cubepal[i][j][k][l] = working[i][j][k][l]
+	for (q = 0; q < 3; q++)
+	{
+		dowork(0, 0, 0, q);
+		dowork(1, 0, 0, q);
+		dowork(0, 1, 0, q);
+		dowork(1, 1, 0, q);
+		dowork(0, 0, 1, q);
+		dowork(1, 0, 1, q);
+		dowork(0, 1, 1, q);
+		dowork(1, 1, 1, q);
+	}
+#undef dowork
+
+	return true;
+}
+
+
+
 // keep a copy of the palette so that we can get the RGB value for a color index at any time.
 static void LoadPalette(const char *lumpname)
 {
-	const UINT8 *usegamma = gammatable[cv_usegamma.value];
+	boolean cube = InitCube();
 	lumpnum_t lumpnum = W_GetNumForName(lumpname);
 	size_t i, palsize = W_LumpLength(lumpnum)/3;
 	UINT8 *pal;
@@ -186,10 +219,54 @@ static void LoadPalette(const char *lumpname)
 	pal = W_CacheLumpNum(lumpnum, PU_CACHE);
 	for (i = 0; i < palsize; i++)
 	{
-		pLocalPalette[i].s.red = usegamma[*pal++];
-		pLocalPalette[i].s.green = usegamma[*pal++];
-		pLocalPalette[i].s.blue = usegamma[*pal++];
+		pLocalPalette[i].s.red = *pal++;
+		pLocalPalette[i].s.green = *pal++;
+		pLocalPalette[i].s.blue = *pal++;
 		pLocalPalette[i].s.alpha = 0xFF;
+
+		// lerp of colour cubing!
+		if (cube)
+		{
+			float working[4][3];
+			float linear;
+			UINT8 q;
+
+			linear = (pLocalPalette[i].s.red/255.0);
+#define dolerp(e1, e2) ((1 - linear)*e1 + linear*e2)
+			for (q = 0; q < 3; q++)
+			{
+				working[0][q] = dolerp(Cubepal[0][0][0][q], Cubepal[1][0][0][q]);
+				working[1][q] = dolerp(Cubepal[0][1][0][q], Cubepal[1][1][0][q]);
+				working[2][q] = dolerp(Cubepal[0][0][1][q], Cubepal[1][0][1][q]);
+				working[3][q] = dolerp(Cubepal[0][1][1][q], Cubepal[1][1][1][q]);
+			}
+			linear = (pLocalPalette[i].s.green/255.0);
+			for (q = 0; q < 3; q++)
+			{
+				working[0][q] = dolerp(working[0][q], working[1][q]);
+				working[1][q] = dolerp(working[2][q], working[3][q]);
+			}
+			linear = (pLocalPalette[i].s.blue/255.0);
+			for (q = 0; q < 3; q++)
+			{
+				working[0][q] = 255*dolerp(working[0][q], working[1][q]);
+				if (working[0][q] > 255.0)
+					working[0][q] = 255.0;
+				else if (working[0][q]  < 0.0)
+					working[0][q] = 0.0;
+			}
+#undef dowork
+
+			/*
+			I don't know what I messed up such that red takes index 2 and blue takes index 0.
+			It should be the other way around, but I've just got this working after spending
+			hours on it and I'm not going to look a gift ho(rse/t)fix in the mouth.
+			toast 18/04/17
+			*/
+			pLocalPalette[i].s.red = (UINT8)(working[0][2]);
+			pLocalPalette[i].s.green = (UINT8)(working[0][1]);
+			pLocalPalette[i].s.blue = (UINT8)(working[0][0]);
+		}
 	}
 }
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -27,8 +27,8 @@
 
 extern UINT8 *screens[5];
 
-extern const UINT8 gammatable[5][256];
-extern consvar_t cv_ticrate, cv_tpscounter, cv_usegamma, cv_allcaps, cv_constextsize;
+
+extern consvar_t cv_ticrate, cv_tpscounter, cv_usegamma, cv_allcaps, cv_constextsize, cv_usesaturation;
 
 // Allocates buffer screens, call before R_Init.
 void V_Init(void);

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -28,7 +28,11 @@
 extern UINT8 *screens[5];
 
 
-extern consvar_t cv_ticrate, cv_tpscounter, cv_usegamma, cv_allcaps, cv_constextsize, cv_usesaturation;
+extern consvar_t cv_ticrate, cv_tpscounter, cv_allcaps, cv_constextsize, \
+cv_globalgamma, cv_globalsaturation, \
+cv_rhue, cv_yhue, cv_ghue, cv_chue, cv_bhue, cv_mhue,\
+cv_rgamma, cv_ygamma, cv_ggamma, cv_cgamma, cv_bgamma, cv_mgamma, \
+cv_rsaturation, cv_ysaturation, cv_gsaturation, cv_csaturation, cv_bsaturation, cv_msaturation;
 
 // Allocates buffer screens, call before R_Init.
 void V_Init(void);


### PR DESCRIPTION
Adds the color cube from 2.2, which allows you to change the game saturation and also allows you to change the saturation, gamma and hue of colors

TODO:

- [ ] Remove OpenGL gamma correction, as it is kind of redundant now and this new code works in software too

And some other stuff I probably forgot
![image](https://github.com/user-attachments/assets/90e2854d-9ba2-4ab3-9d6b-e384c4362b60)

