### PR TITLE
Fix issues with uninitialized variables on polyobject thinkers

### DIFF
--- a/src/p_polyobj.c
+++ b/src/p_polyobj.c
@@ -150,6 +150,7 @@ FUNCINLINE static ATTRINLINE void PolyObj_AddThinker(thinker_t *th)
 	th->next = thinkercap.next;
 	th->prev = &thinkercap;
 	thinkercap.next = th;
+	th->references = 0;
 }
 
 //

--- a/src/p_polyobj.c
+++ b/src/p_polyobj.c
@@ -151,6 +151,8 @@ FUNCINLINE static ATTRINLINE void PolyObj_AddThinker(thinker_t *th)
 	th->prev = &thinkercap;
 	thinkercap.next = th;
 	th->references = 0;
+
+	th->cachable = false;
 }
 
 //
@@ -2423,7 +2425,7 @@ INT32 EV_DoPolyObjMove(polymovedata_t *pmdata)
 	// TODO: start sound sequence event
 
 	oldpo = po;
-    
+
 	R_CreateInterpolator_Polyobj(&th->thinker, po);
 
 	// apply action to mirroring polyobjects as well
@@ -2597,7 +2599,7 @@ INT32 EV_DoPolyObjWaypoint(polywaypointdata_t *pwdata)
 
 		// T_PolyObjWaypoint is the only polyobject movement
 	// that can adjust z, so we add these ones too.
-	R_CreateInterpolator_SectorPlane(&th->thinker, po->lines[0]->backsector, false); 
+	R_CreateInterpolator_SectorPlane(&th->thinker, po->lines[0]->backsector, false);
 	R_CreateInterpolator_SectorPlane(&th->thinker, po->lines[0]->backsector, true);
 
 	// Most other polyobject functions handle children by recursively
@@ -2776,7 +2778,7 @@ INT32 EV_DoPolyObjDisplace(polydisplacedata_t *prdata)
 	th->dy = prdata->dy;
 
 	oldpo = po;
-	
+
 	R_CreateInterpolator_Polyobj(&th->thinker, po);
 
 	// apply action to mirroring polyobjects as well

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -232,16 +232,17 @@ void P_RemoveThinkerDelayed(void *pthinker)
 			(next->prev = currentthinker = thinker->prev)->next = next;
 		}
 		R_DestroyLevelInterpolators(thinker);
-	if (thinker->cachable == true)
-	{
-		// put cachable thinkers in the mobj cache, so we can avoid allocations
-		((mobj_t *)thinker)->hnext = mobjcache;
-		mobjcache = (mobj_t *)thinker;
-	}
-	else
-	{
-		Z_Free(thinker);
-	}
+
+		if (thinker->cachable == true)
+		{
+			// put cachable thinkers in the mobj cache, so we can avoid allocations
+			((mobj_t *)thinker)->hnext = mobjcache;
+			mobjcache = (mobj_t *)thinker;
+		}
+		else
+		{
+			Z_Free(thinker);
+		}
 	}
 }
 
@@ -579,7 +580,7 @@ static inline void P_DoCTFStuff(void)
 //
 void P_Ticker(boolean run)
 {
-	INT32 i; 
+	INT32 i;
 
 
 	//Increment jointime even if paused.
@@ -610,7 +611,7 @@ void P_Ticker(boolean run)
 	P_MapStart();
 
 	if (run)
-	{ 
+	{
 		R_UpdateMobjInterpolators();
 		if (demorecording)
 			G_WriteDemoTiccmd(&players[consoleplayer].cmd, 0);
@@ -646,7 +647,7 @@ void P_Ticker(boolean run)
 		P_EmeraldManager(); // Power stone mode
 
 	if (run)
-	{	
+	{
 		PS_START_TIMING(ps_thinkertime);
 		P_RunThinkers();
 		PS_STOP_TIMING(ps_thinkertime);
@@ -728,7 +729,7 @@ void P_Ticker(boolean run)
 		if (modeattacking)
 			G_GhostTicker();
 	}
- 
+
  	if (run)
 	{
 		R_UpdateLevelInterpolators();
@@ -765,9 +766,9 @@ void P_Ticker(boolean run)
 		}
 	}
 
-	P_MapEnd(); 
+	P_MapEnd();
 
-	
+
 
 
 //	Z_CheckMemCleanup();
@@ -818,7 +819,7 @@ void P_PreTicker(INT32 frames)
 
 		P_UpdateSpecials();
 		P_RespawnSpecials();
-		
+
 		R_UpdateLevelInterpolators();
 		R_UpdateViewInterpolation();
 		R_ResetViewInterpolation(0);


### PR DESCRIPTION
Fixes two issues caused by uninitialized variables on polyobject thinkers
"references" being uninitialized caused them to not be freed by P_RemoveThinkerDelayed in many cases
"cachable" being uninitialized was causing undefined behaviour when trying to spawn mobjs from the mobjcache as it interpreted polyobject thinkers as being cachable