### PR TITLE
Fix z-fighting in OpenGL

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -442,7 +442,7 @@ void SCR_DisplayTicRate(void)
 		V_DrawString(vid.width-(40*vid.dupx), h-(8*vid.dupy),
 			ticcntcolor|V_NOSCALESTART, va("%02d/%02u", totaltics, TICRATE));
 	}
-		lasttic = ontic;
+	lasttic = ontic;
 }
 
 void SCR_DisplayLocalPing(void)

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -1529,7 +1529,14 @@ static SDL_bool Impl_CreateWindow(SDL_bool fullscreen)
 
 #ifdef HWRENDER
 	if (rendermode == render_opengl)
+	{
 		flags |= SDL_WINDOW_OPENGL;
+
+		// Without a 24-bit depth buffer many visuals are ruined by z-fighting.
+		// Some GPU drivers may give us a 16-bit depth buffer since the
+		// default value for SDL_GL_DEPTH_SIZE is 16.
+		SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+	}
 #endif
 
 	// Create a window


### PR DESCRIPTION
Backport of an old 2.2 fix that fixes z-fighting in OpenGL for the most part. It simply increases the depth buffer to make up for the lost accuracy on polygons that are further away from the camera.