### PR TITLE
Port Kart's dedicated server idle

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -4859,6 +4859,9 @@ static inline void PingUpdate(void)
 }
 #endif
 
+// If a tree falls in the forest but nobody is around to hear it, does it make a tic?
+//#define DEDICATEDIDLETIME (10*TICRATE)
+
 void NetUpdate(void)
 {
 	static tic_t gametime = 0;
@@ -4872,6 +4875,55 @@ void NetUpdate(void)
 
 	if (realtics <= 0) // nothing new to update
 		return;
+
+#ifdef DEDICATEDIDLETIME
+	if (server && dedicated && gamestate == GS_LEVEL)
+	{
+		static tic_t dedicatedidle = 0;
+
+		for (i = 1; i < MAXNETNODES; ++i)
+			if (nodeingame[i])
+			{
+				if (dedicatedidle == DEDICATEDIDLETIME)
+				{
+					CONS_Printf("DEDICATED: Awakening from idle (Node %d detected...)\n", i);
+					dedicatedidle = 0;
+				}
+				break;
+			}
+
+		if (i == MAXNETNODES)
+		{
+			if (leveltime == 2)
+			{
+				// On next tick...
+				dedicatedidle = DEDICATEDIDLETIME-1;
+			}
+			else if (dedicatedidle == DEDICATEDIDLETIME)
+			{
+				if (D_GetExistingTextcmd(gametic, 0) || D_GetExistingTextcmd(gametic+1, 0))
+				{
+					CONS_Printf("DEDICATED: Awakening from idle (Netxcmd detected...)\n");
+					dedicatedidle = 0;
+				}
+				else
+				{
+					realtics = 0;
+				}
+			}
+			else if (++dedicatedidle == DEDICATEDIDLETIME)
+			{
+				char *idlereason = "at round start";
+				if (leveltime > 3)
+					idlereason = va("for %d seconds", dedicatedidle/TICRATE);
+
+				CONS_Printf("DEDICATED: No nodes %s, idling...\n", idlereason);
+				realtics = 0;
+			}
+		}
+	}
+#endif
+
 	if (realtics > 5)
 	{
 		if (server)

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -4860,7 +4860,7 @@ static inline void PingUpdate(void)
 #endif
 
 // If a tree falls in the forest but nobody is around to hear it, does it make a tic?
-//#define DEDICATEDIDLETIME (10*TICRATE)
+#define DEDICATEDIDLETIME (10*TICRATE)
 
 void NetUpdate(void)
 {

--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -4913,7 +4913,7 @@ void NetUpdate(void)
 			}
 			else if (++dedicatedidle == DEDICATEDIDLETIME)
 			{
-				char *idlereason = "at round start";
+				const char *idlereason = "at round start";
 				if (leveltime > 3)
 					idlereason = va("for %d seconds", dedicatedidle/TICRATE);
 


### PR DESCRIPTION
Adds Kart's dedicated server idle which freezes the server if no nodes are there for more than 10 seconds, saving resources.
![Screenshot_20250423_172340](https://github.com/user-attachments/assets/24f80699-f7ed-4e2f-ba68-f41bf4c7fba3)
