### PR TITLE
Fix dedicated build

### DIFF
--- a/src/dedicated/i_main.c
+++ b/src/dedicated/i_main.c
@@ -67,7 +67,6 @@ typedef BOOL (WINAPI *p_IsDebuggerPresent)(VOID);
 int main(int argc, char **argv)
 {
 	const char *logdir = NULL;
-	char logfile[MAX_WADPATH];
 	myargc = argc;
 	myargv = argv; /// \todo pull out path to exe from this string
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -8035,9 +8035,11 @@ boolean P_MoveChaseCamera(player_t *player, camera_t *thiscam, boolean resetcall
 
 	if ((camorbit) && player->playerstate != PST_DEAD && !(mo->flags2 & MF2_TWOD) &&  !twodlevel)
 	{
+#ifndef DEDICATED
 		if (rendermode == render_opengl && !cv_grshearing.value)
 			distxy = FixedMul(dist, FINECOSINE((focusaiming>>ANGLETOFINESHIFT) & FINEMASK));
 		else
+#endif
 			distxy = dist;
 		distz = -FixedMul(dist, FINESINE((focusaiming>>ANGLETOFINESHIFT) & FINEMASK)) + slopez;
 	}


### PR DESCRIPTION
`cv_grshearing` doesn't exist on dedicated builds since the concept of rendering doesn't exist, so it needs to be excluded from that build type.

The patch also fixes an unused variable warning in dedicated builds.