### PR TITLE
Add FPS/TPS counter sizes

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1164,9 +1164,10 @@ static menuitem_t OP_VideoOptionsMenu[] =
 	{IT_STRING | IT_CVAR,  NULL, "Precip Density",        &cv_precipdensity,        60},
 	{IT_STRING | IT_CVAR,  NULL, "Show FPS",              &cv_ticrate,              65},
 	{IT_STRING | IT_CVAR,  NULL, "Show TPS",              &cv_tpscounter,           70},
-	{IT_STRING | IT_CVAR,  NULL, "Clear Before Redraw",   &cv_homremoval,           75},
-	{IT_STRING | IT_CVAR,  NULL, "Vertical Sync",         &cv_vidwait,              80},
-	{IT_STRING | IT_CVAR,  NULL, "FPS Cap",               &cv_fpscap,               85},
+	{IT_STRING | IT_CVAR,  NULL, "FPS/TPS Counter Size",  &cv_fpssize,              75},
+	{IT_STRING | IT_CVAR,  NULL, "Clear Before Redraw",   &cv_homremoval,           80},
+	{IT_STRING | IT_CVAR,  NULL, "Vertical Sync",         &cv_vidwait,              85},
+	{IT_STRING | IT_CVAR,  NULL, "FPS Cap",               &cv_fpscap,               90},
 };
 
 static menuitem_t OP_ColorOptionsMenu[] =
@@ -7296,7 +7297,7 @@ static void M_HandleConnectIP(INT32 choice)
 			}
 			if (!shiftdown) // Shift+Delete is used for something else.
 				break;
-				
+
 			/* FALLTHRU */
 
 		default:
@@ -7312,7 +7313,7 @@ static void M_HandleConnectIP(INT32 choice)
 					case 'V': // ctrl+v, pasting
 					{
 						const char *paste = I_ClipboardPaste();
-						
+
 						if (paste != NULL) {
 							strncat(setupm_ip, paste, 28-1 - l); // Concat the ip field with clipboard
 							if (strlen(paste) != 0) // Don't play sound if nothing was pasted
@@ -7346,7 +7347,7 @@ static void M_HandleConnectIP(INT32 choice)
 					case KEY_INS: // shift+insert, pasting
 						{
 							const char *paste = I_ClipboardPaste();
-							
+
 							if (paste != NULL) {
 								strncat(setupm_ip, paste, 28-1 - l); // Concat the ip field with clipboard
 								if (strlen(paste) != 0) // Don't play sound if nothing was pasted

--- a/src/screen.c
+++ b/src/screen.c
@@ -411,7 +411,7 @@ void SCR_DisplayTicRate(void)
 	{
 		switch (cv_fpssize.value)
 		{
-		case 0:
+			case 0:
 				V_DrawRightAlignedString(vid.width, h,
 					fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
 				break;
@@ -433,7 +433,7 @@ void SCR_DisplayTicRate(void)
 	else if (cv_ticrate.value == 1) // full counter
 	{
 		const char *drawnstr;
-		INT32 width; 
+		INT32 width;
 
 		// The highest assignable cap is < 1000, so 3 characters is fine.
 		if (cap > 0)
@@ -445,7 +445,7 @@ void SCR_DisplayTicRate(void)
 		{
 			case 0:
 				width = V_StringWidth(drawnstr, V_NOSCALESTART);
-				V_DrawString(vid.width - ((7 * 8 * vid.dupx) + V_StringWidth("FPS: ", V_NOSCALESTART)), h,
+				V_DrawString(vid.width - ((7 * 6 * vid.dupx) + V_StringWidth("FPS: ", V_NOSCALESTART)), h,
 					V_YELLOWMAP|V_NOSCALESTART, "FPS: ");
 				V_DrawString(vid.width - width, h,
 					fpscntcolor|V_NOSCALESTART, drawnstr);
@@ -500,7 +500,7 @@ void SCR_DisplayTicRate(void)
 		switch (cv_fpssize.value)
 		{
 			case 0:
-				V_DrawString(vid.width - ((7 * 8 * vid.dupx) + V_StringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
+				V_DrawString(vid.width - ((7 * 6 * vid.dupx) + V_StringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
 					V_YELLOWMAP|V_NOSCALESTART, "TPS: ");
 				V_DrawRightAlignedString(vid.width, h-hstep,
 					ticcntcolor|V_NOSCALESTART, va("%d/%u", totaltics, TICRATE));

--- a/src/screen.c
+++ b/src/screen.c
@@ -380,7 +380,6 @@ void SCR_DisplayTicRate(void)
 	tic_t i;
 	tic_t ontic = I_GetTime();
 	tic_t totaltics = 0;
-	INT32 width;
 
 	if (gamestate == GS_NULL)
 		return;
@@ -412,29 +411,18 @@ void SCR_DisplayTicRate(void)
 	{
 		switch (cv_fpssize.value)
 		{
-			case 0:
-			{
-				width = vid.dupx*V_StringWidth(va("%04.2f", averageFPS), V_NOSCALESTART); //this used to be a monstrosity
-				V_DrawString(vid.width-width, h,
+		case 0:
+				V_DrawRightAlignedString(vid.width, h,
 					fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
 				break;
-			}
-
 			case 1:
-			{
-				width = vid.dupx*V_ThinStringWidth(va("%04.2f", averageFPS), V_NOSCALESTART); //this used to be a monstrosity
-				V_DrawThinString(vid.width-width, h,
+				V_DrawRightAlignedThinString(vid.width, h,
 					fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
 				break;
-			}
-
 			case 2:
-			{
-				width = vid.dupx*V_SmallStringWidth(va("%04.2f", averageFPS), V_NOSCALESTART); //this used to be a monstrosity
-				V_DrawSmallString(vid.width-width, h,
+				V_DrawRightAlignedSmallString(vid.width, h,
 					fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
 				break;
-			}
 		}
 
 		if (cv_fpssize.value == 2)
@@ -445,6 +433,7 @@ void SCR_DisplayTicRate(void)
 	else if (cv_ticrate.value == 1) // full counter
 	{
 		const char *drawnstr;
+		INT32 width; 
 
 		// The highest assignable cap is < 1000, so 3 characters is fine.
 		if (cap > 0)
@@ -455,34 +444,26 @@ void SCR_DisplayTicRate(void)
 		switch (cv_fpssize.value)
 		{
 			case 0:
-			{
-				width = vid.dupx*V_StringWidth(drawnstr, V_NOSCALESTART); //same here
-				V_DrawString((vid.width - 92 * vid.dupx + V_StringWidth("FPS: ", V_NOSCALESTART)), h,
-						V_YELLOWMAP|V_NOSCALESTART, "FPS:");
+				width = V_StringWidth(drawnstr, V_NOSCALESTART);
+				V_DrawString(vid.width - ((7 * 8 * vid.dupx) + V_StringWidth("FPS: ", V_NOSCALESTART)), h,
+					V_YELLOWMAP|V_NOSCALESTART, "FPS: ");
 				V_DrawString(vid.width - width, h,
-						fpscntcolor|V_NOSCALESTART, drawnstr);
+					fpscntcolor|V_NOSCALESTART, drawnstr);
 				break;
-			}
-
 			case 1:
-			{
-				width = vid.dupx*V_ThinStringWidth(drawnstr, V_NOSCALESTART); //same here
-				V_DrawThinString((vid.width - 92 * vid.dupx + V_ThinStringWidth("FPS: ", V_NOSCALESTART)), h,
-						V_YELLOWMAP|V_NOSCALESTART, "FPS:");
+				width = V_ThinStringWidth(drawnstr, V_NOSCALESTART);
+				V_DrawThinString(vid.width - ((7 * 4 * vid.dupx) + V_ThinStringWidth("FPS: ", V_NOSCALESTART)), h,
+					V_YELLOWMAP|V_NOSCALESTART, "FPS: ");
 				V_DrawThinString(vid.width - width, h,
-						fpscntcolor|V_NOSCALESTART, drawnstr);
+					fpscntcolor|V_NOSCALESTART, drawnstr);
 				break;
-			}
-
 			case 2:
-			{
-				width = vid.dupx*V_SmallStringWidth(drawnstr, V_NOSCALESTART); //same here
-				V_DrawSmallString((vid.width - 92 * vid.dupx + V_SmallStringWidth("FPS: ", V_NOSCALESTART)), h,
-						V_YELLOWMAP|V_NOSCALESTART, "FPS:");
+				width = V_SmallStringWidth(drawnstr, V_NOSCALESTART);
+				V_DrawSmallString(vid.width - ((7 * 4 * vid.dupx) + V_SmallStringWidth("FPS: ", V_NOSCALESTART)), h,
+					V_YELLOWMAP|V_NOSCALESTART, "FPS: ");
 				V_DrawSmallString(vid.width - width, h,
-						fpscntcolor|V_NOSCALESTART, drawnstr);
+					fpscntcolor|V_NOSCALESTART, drawnstr);
 				break;
-			}
 		}
 
 		if (cv_fpssize.value == 2)
@@ -496,67 +477,48 @@ void SCR_DisplayTicRate(void)
 		switch (cv_fpssize.value)
 		{
 			case 0:
-			{
-				width = vid.dupx*V_StringWidth(va("%02d", totaltics), V_NOSCALESTART); //this used to be a monstrosity
-				V_DrawString(vid.width-width, h-hstep,
-					ticcntcolor|V_NOSCALESTART, va("%02d", totaltics));
+				V_DrawRightAlignedString(vid.width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%d", totaltics));
 				break;
-			}
 
 			case 1:
-			{
-				width = vid.dupx*V_ThinStringWidth(va("%02d", totaltics), V_NOSCALESTART); //this used to be a monstrosity
-				V_DrawThinString(vid.width-width, h-hstep,
-					ticcntcolor|V_NOSCALESTART, va("%02d", totaltics));
+				V_DrawRightAlignedThinString(vid.width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%d", totaltics));
 				break;
-			}
 
 			case 2:
-			{
-				width = vid.dupx*V_SmallStringWidth(va("%02d", totaltics), V_NOSCALESTART); //this used to be a monstrosity
-				V_DrawSmallString(vid.width-width, h-hstep,
-					ticcntcolor|V_NOSCALESTART, va("%02d", totaltics));
+				V_DrawRightAlignedSmallString(vid.width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%d", totaltics));
 				break;
-			}
 		}
 	}
 	else if (cv_tpscounter.value == 1) // full counter
 	{
-		const char *drawnstr = va("%02d/%02d", totaltics, TICRATE);
 
 		// The highest assignable cap is < 1000, so 3 characters is fine.
 
 		switch (cv_fpssize.value)
 		{
 			case 0:
-			{
-				width = vid.dupx*V_StringWidth(drawnstr, V_NOSCALESTART); //same here
-				V_DrawString((vid.width - 92 * vid.dupx + V_StringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
-					V_YELLOWMAP|V_NOSCALESTART, "TPS:");
-				V_DrawString(vid.width-width, h-hstep,
-					ticcntcolor|V_NOSCALESTART, drawnstr);
+				V_DrawString(vid.width - ((7 * 8 * vid.dupx) + V_StringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
+					V_YELLOWMAP|V_NOSCALESTART, "TPS: ");
+				V_DrawRightAlignedString(vid.width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%d/%u", totaltics, TICRATE));
 				break;
-			}
 
 			case 1:
-			{
-				width = vid.dupx*V_ThinStringWidth(drawnstr, V_NOSCALESTART); //same here
-				V_DrawThinString((vid.width - 92 * vid.dupx + V_ThinStringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
-					V_YELLOWMAP|V_NOSCALESTART, "TPS:");
-				V_DrawThinString(vid.width-width, h-hstep,
-					ticcntcolor|V_NOSCALESTART, drawnstr);
+				V_DrawThinString(vid.width - ((7 * 4 * vid.dupx) + V_ThinStringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
+					V_YELLOWMAP|V_NOSCALESTART, "TPS: ");
+				V_DrawRightAlignedThinString(vid.width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%d/%u", totaltics, TICRATE));
 				break;
-			}
 
 			case 2:
-			{
-				width = vid.dupx*V_SmallStringWidth(drawnstr, V_NOSCALESTART); //same here
-				V_DrawSmallString((vid.width - 92 * vid.dupx + V_SmallStringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
-					V_YELLOWMAP|V_NOSCALESTART, "TPS:");
-				V_DrawSmallString(vid.width-width, h-hstep,
-					ticcntcolor|V_NOSCALESTART, drawnstr);
+				V_DrawSmallString(vid.width - ((7 * 4 * vid.dupx) + V_SmallStringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
+					V_YELLOWMAP|V_NOSCALESTART, "TPS: ");
+				V_DrawRightAlignedSmallString(vid.width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%d/%u", totaltics, TICRATE));
 				break;
-			}
 		}
 	}
 	lasttic = ontic;

--- a/src/screen.c
+++ b/src/screen.c
@@ -454,7 +454,7 @@ void SCR_DisplayTicRate(void)
 
 		switch (cv_fpssize.value)
 		{
-			case 0: 
+			case 0:
 			{
 				width = vid.dupx*V_StringWidth(drawnstr, V_NOSCALESTART); //same here
 				V_DrawString((vid.width - 92 * vid.dupx + V_StringWidth("FPS: ", V_NOSCALESTART)), h,
@@ -568,7 +568,7 @@ void SCR_DisplayLocalPing(void)
 	if (cv_showping.value)
 	{
 		INT32 dispy;
-		
+
 		if(cv_tpscounter.value)
 			dispy = 172;
 		else

--- a/src/screen.c
+++ b/src/screen.c
@@ -178,6 +178,7 @@ void SCR_Startup(void)
 	V_Init();
 	CV_RegisterVar(&cv_ticrate);
 	CV_RegisterVar(&cv_tpscounter);
+	CV_RegisterVar(&cv_fpssize);
 	CV_RegisterVar(&cv_constextsize);
 
 	V_SetPalette(0);
@@ -370,14 +371,15 @@ void SCR_CalculateFPS(void)
 
 void SCR_DisplayTicRate(void)
 {
-	INT32 fpscntcolor = 0;
-	const INT32 h = vid.height-(8*vid.dupy);
+	INT32 fpscntcolor = 0, ticcntcolor = 0;
+	const INT32 fontheight = cv_fpssize.value == 1 ? 7 : 8;
+	const INT32 h = vid.height-((cv_fpssize.value == 2 ? 4 : fontheight)*vid.dupy);
 	UINT32 cap = R_GetFramerateCap();
 	double fps = round(averageFPS);
+	INT32 hstep = 0;
 	tic_t i;
 	tic_t ontic = I_GetTime();
 	tic_t totaltics = 0;
-	INT32 ticcntcolor = 0;
 	INT32 width;
 
 	if (gamestate == GS_NULL)
@@ -408,10 +410,37 @@ void SCR_DisplayTicRate(void)
 
 	if (cv_ticrate.value == 2) // compact counter
 	{
-		width = vid.dupx*V_StringWidth(va("%04.2f", averageFPS), V_NOSCALESTART); //this used to be a monstrosity
+		switch (cv_fpssize.value)
+		{
+			case 0:
+			{
+				width = vid.dupx*V_StringWidth(va("%04.2f", averageFPS), V_NOSCALESTART); //this used to be a monstrosity
+				V_DrawString(vid.width-width, h,
+					fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
+				break;
+			}
 
-		V_DrawString(vid.width-width, h,
-			fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
+			case 1:
+			{
+				width = vid.dupx*V_ThinStringWidth(va("%04.2f", averageFPS), V_NOSCALESTART); //this used to be a monstrosity
+				V_DrawThinString(vid.width-width, h,
+					fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
+				break;
+			}
+
+			case 2:
+			{
+				width = vid.dupx*V_SmallStringWidth(va("%04.2f", averageFPS), V_NOSCALESTART); //this used to be a monstrosity
+				V_DrawSmallString(vid.width-width, h,
+					fpscntcolor|V_NOSCALESTART, va("%04.2f", averageFPS)); // use averageFPS directly
+				break;
+			}
+		}
+
+		if (cv_fpssize.value == 2)
+			hstep = 4*vid.dupy;
+		else
+			hstep = 8*vid.dupy;
 	}
 	else if (cv_ticrate.value == 1) // full counter
 	{
@@ -423,24 +452,112 @@ void SCR_DisplayTicRate(void)
 		else
 			drawnstr = va("%4.2f", averageFPS);
 
-		width = vid.dupx*V_StringWidth(drawnstr, V_NOSCALESTART); //same here
+		switch (cv_fpssize.value)
+		{
+			case 0: 
+			{
+				width = vid.dupx*V_StringWidth(drawnstr, V_NOSCALESTART); //same here
+				V_DrawString((vid.width - 92 * vid.dupx + V_StringWidth("FPS: ", V_NOSCALESTART)), h,
+						V_YELLOWMAP|V_NOSCALESTART, "FPS:");
+				V_DrawString(vid.width - width, h,
+						fpscntcolor|V_NOSCALESTART, drawnstr);
+				break;
+			}
 
-		V_DrawString((vid.width - 92 * vid.dupx + V_StringWidth("FPS: ", V_NOSCALESTART)), h,
-			V_YELLOWMAP|V_NOSCALESTART, "FPS:");
-		V_DrawString(vid.width - width, h,
-				fpscntcolor|V_NOSCALESTART, drawnstr);
+			case 1:
+			{
+				width = vid.dupx*V_ThinStringWidth(drawnstr, V_NOSCALESTART); //same here
+				V_DrawThinString((vid.width - 92 * vid.dupx + V_ThinStringWidth("FPS: ", V_NOSCALESTART)), h,
+						V_YELLOWMAP|V_NOSCALESTART, "FPS:");
+				V_DrawThinString(vid.width - width, h,
+						fpscntcolor|V_NOSCALESTART, drawnstr);
+				break;
+			}
 
+			case 2:
+			{
+				width = vid.dupx*V_SmallStringWidth(drawnstr, V_NOSCALESTART); //same here
+				V_DrawSmallString((vid.width - 92 * vid.dupx + V_SmallStringWidth("FPS: ", V_NOSCALESTART)), h,
+						V_YELLOWMAP|V_NOSCALESTART, "FPS:");
+				V_DrawSmallString(vid.width - width, h,
+						fpscntcolor|V_NOSCALESTART, drawnstr);
+				break;
+			}
+		}
+
+		if (cv_fpssize.value == 2)
+			hstep = 4*vid.dupy;
+		else
+			hstep = 8*vid.dupy;
 	}
 
 	if (cv_tpscounter.value == 2) // compact counter
-		V_DrawString(vid.width-(16*vid.dupx), h-(8*vid.dupy),
-			ticcntcolor|V_NOSCALESTART, va("%02d", totaltics));
+	{
+		switch (cv_fpssize.value)
+		{
+			case 0:
+			{
+				width = vid.dupx*V_StringWidth(va("%02d", totaltics), V_NOSCALESTART); //this used to be a monstrosity
+				V_DrawString(vid.width-width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%02d", totaltics));
+				break;
+			}
+
+			case 1:
+			{
+				width = vid.dupx*V_ThinStringWidth(va("%02d", totaltics), V_NOSCALESTART); //this used to be a monstrosity
+				V_DrawThinString(vid.width-width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%02d", totaltics));
+				break;
+			}
+
+			case 2:
+			{
+				width = vid.dupx*V_SmallStringWidth(va("%02d", totaltics), V_NOSCALESTART); //this used to be a monstrosity
+				V_DrawSmallString(vid.width-width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, va("%02d", totaltics));
+				break;
+			}
+		}
+	}
 	else if (cv_tpscounter.value == 1) // full counter
 	{
-		V_DrawString((vid.width - 92 * vid.dupx + V_StringWidth("TPS: ", V_NOSCALESTART)), h-(8*vid.dupy),
-			V_YELLOWMAP|V_NOSCALESTART, "TPS:");
-		V_DrawString(vid.width-(40*vid.dupx), h-(8*vid.dupy),
-			ticcntcolor|V_NOSCALESTART, va("%02d/%02u", totaltics, TICRATE));
+		const char *drawnstr = va("%02d/%02d", totaltics, TICRATE);
+
+		// The highest assignable cap is < 1000, so 3 characters is fine.
+
+		switch (cv_fpssize.value)
+		{
+			case 0:
+			{
+				width = vid.dupx*V_StringWidth(drawnstr, V_NOSCALESTART); //same here
+				V_DrawString((vid.width - 92 * vid.dupx + V_StringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
+					V_YELLOWMAP|V_NOSCALESTART, "TPS:");
+				V_DrawString(vid.width-width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, drawnstr);
+				break;
+			}
+
+			case 1:
+			{
+				width = vid.dupx*V_ThinStringWidth(drawnstr, V_NOSCALESTART); //same here
+				V_DrawThinString((vid.width - 92 * vid.dupx + V_ThinStringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
+					V_YELLOWMAP|V_NOSCALESTART, "TPS:");
+				V_DrawThinString(vid.width-width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, drawnstr);
+				break;
+			}
+
+			case 2:
+			{
+				width = vid.dupx*V_SmallStringWidth(drawnstr, V_NOSCALESTART); //same here
+				V_DrawSmallString((vid.width - 92 * vid.dupx + V_SmallStringWidth("TPS: ", V_NOSCALESTART)), h-hstep,
+					V_YELLOWMAP|V_NOSCALESTART, "TPS:");
+				V_DrawSmallString(vid.width-width, h-hstep,
+					ticcntcolor|V_NOSCALESTART, drawnstr);
+				break;
+			}
+		}
 	}
 	lasttic = ontic;
 }

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -2465,6 +2465,9 @@ INT32 V_StringWidth(const char *string, INT32 option)
 			w += (charwidth ? charwidth : SHORT(hu_font[c]->width));
 	}
 
+	if (option & V_NOSCALESTART)
+		w *= vid.dupx;
+
 	return w;
 }
 
@@ -2504,6 +2507,9 @@ INT32 V_SmallStringWidth(const char *string, INT32 option)
 			w += (charwidth ? charwidth : SHORT(hu_font[c]->width)/2);
 	}
 
+	if (option & V_NOSCALESTART)
+		w *= vid.dupx;
+
 	return w;
 }
 
@@ -2542,6 +2548,9 @@ INT32 V_ThinStringWidth(const char *string, INT32 option)
 		else
 			w += (charwidth ? charwidth : SHORT(tny_font[c]->width));
 	}
+
+	if (option & V_NOSCALESTART)
+		w *= vid.dupx;
 
 	return w;
 }

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -42,6 +42,8 @@ static CV_PossibleValue_t ticrate_cons_t[] = { {0, "No"}, {1, "Full"}, {2, "Comp
 static CV_PossibleValue_t tpscounter_cons_t[] = { {0, "No"}, {1, "Full"}, {2, "Compact"}, {0, NULL} };
 consvar_t cv_ticrate = { "showfps", "No", CV_SAVE, ticrate_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL };
 consvar_t cv_tpscounter = { "showtps", "No", CV_SAVE, tpscounter_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL };
+static CV_PossibleValue_t fpssize_cons_t[] = { {0, "Normal"}, {1, "Thin"}, {2, "Small"}, {0, NULL} };
+consvar_t cv_fpssize = { "fpssize", "Normal", CV_SAVE, fpssize_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL };
 
 static void CV_palette_OnChange(void);
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -27,7 +27,7 @@
 
 extern UINT8 *screens[5];
 
-extern consvar_t cv_ticrate, cv_tpscounter, cv_allcaps, cv_constextsize, \
+extern consvar_t cv_ticrate, cv_tpscounter, cv_fpssize, cv_allcaps, cv_constextsize, \
 cv_globalgamma, cv_globalsaturation, \
 cv_rhue, cv_yhue, cv_ghue, cv_chue, cv_bhue, cv_mhue,\
 cv_rgamma, cv_ygamma, cv_ggamma, cv_cgamma, cv_bgamma, cv_mgamma, \


### PR DESCRIPTION
Adds FPS/TPS counter sizes from SRB2Classic where you can select between like "Normal", "Thin" and "Small".

![image](https://github.com/user-attachments/assets/68cca673-f147-4fe5-8468-866e36fc5a6a)