### PR TITLE
Lua I/O library from 2.2

### DIFF
--- a/src/blua/liolib.c
+++ b/src/blua/liolib.c
@@ -18,25 +18,30 @@
 #include "lauxlib.h"
 #include "lualib.h"
 #include "../i_system.h"
-#include "../doomdef.h"
-#include "../d_main.h"
+#include "../g_game.h"
+#include "../d_netfil.h"
+#include "../lua_libs.h"
+#include "../byteptr.h"
+#include "../lua_script.h"
 #include "../m_misc.h"
-
 
 
 #define IO_INPUT	1
 #define IO_OUTPUT	2
 
-#define FILELIMIT 1024*1024 // Size limit for reading/writing files
+#define FILELIMIT (1024 * 1024) // Size limit for reading/writing files
+
+#define FMT_FILECALLBACKID "file_callback_%d"
 
 
-static const char *const fnames[] = {"input", "output"};
 static const char *whitelist[] = { // Allow scripters to write files of these types to SRB2's folder
-	".txt",
-	".sav2",
+	".bmp",
 	".cfg",
+	".csv",
+	".dat",
 	".png",
-	".bmp"
+	".sav2",
+	".txt",
 };
 
 
@@ -55,12 +60,6 @@ static int pushresult (lua_State *L, int i, const char *filename) {
     lua_pushinteger(L, en);
     return 3;
   }
-}
-
-
-static void fileerror (lua_State *L, int arg, const char *filename) {
-  lua_pushfstring(L, "%s: %s", filename, strerror(errno));
-  luaL_argerror(L, arg, lua_tostring(L, -1));
 }
 
 
@@ -159,59 +158,192 @@ static int io_tostring (lua_State *L) {
   return 1;
 }
 
-static int StartsWith(const char *a, const char *b) // this is wolfs being lazy yet again
+
+// Create directories in the path
+void MakePathDirs(char *path)
 {
-   if(strncmp(a, b, strlen(b)) == 0) return 1;
-   return 0;
+	char *c;
+
+	for (c = path; *c; c++)
+		if (*c == '/' || *c == '\\')
+		{
+			char sep = *c;
+			*c = '\0';
+			I_mkdir(path, 0755);
+			*c = sep;
+		}
 }
 
 
-static int io_open (lua_State *L) {
-	FILE **pf;
-	const char *filename = luaL_checkstring(L, 1);
-	int pass = 0;
-	size_t i;
+static int CheckFileName(lua_State *L, const char *filename)
+{
 	int length = strlen(filename);
-	char *splitter, *forward, *backward;
-	char *destFilename;
-	const char *mode = luaL_optstring(L, 2, "r");
+	boolean pass = false;
+	size_t i;
 
-	for (i = 0; i < (sizeof (whitelist) / sizeof(const char *)); i++)
+	if (strchr(filename, '\\'))
 	{
-		if (!stricmp(&filename[length - strlen(whitelist[i])], whitelist[i]))
-		{
-			pass = 1;
-			break;
-		}
-	}
-	if (strstr(filename, "..") || strchr(filename, ':') || StartsWith(filename, "\\")
-		|| StartsWith(filename, "/") || !pass)
-	{
-		luaL_error(L,"access denied to %s", filename);
+		luaL_error(L, "access denied to %s: \\ is not allowed, use / instead", filename);
 		return pushresult(L,0,filename);
 	}
 
-	destFilename = va("%s"PATHSEP"luafiles"PATHSEP"%s", srb2home, filename);
-
-	// Make directories as needed
-	splitter = destFilename;
-
-    forward = strchr(splitter, '/');
-    backward = strchr(splitter, '\\');
-	while ((splitter = (forward && backward) ? min(forward, backward) : (forward ?: backward)))
+	for (i = 0; i < (sizeof (whitelist) / sizeof(const char *)); i++)
+		if (!stricmp(&filename[length - strlen(whitelist[i])], whitelist[i]))
+		{
+			pass = true;
+			break;
+		}
+	if (strstr(filename, "./")
+		|| strstr(filename, "..") || strchr(filename, ':')
+		|| filename[0] == '/'
+		|| !pass)
 	{
-		*splitter = 0;
-		I_mkdir(destFilename, 0755);
-		*splitter = '/'; 
-		splitter++;
-
-        forward = strchr(splitter, '/');
-        backward = strchr(splitter, '\\');
+		luaL_error(L, "access denied to %s", filename);
+		return pushresult(L,0,filename);
 	}
 
+	return 0;
+}
+
+static int io_opennew (lua_State *L) {
+	const char *filename = luaL_checkstring(L, 1);
+	const char *mode = luaL_optstring(L, 2, "r");
+	int checkresult;
+
+	checkresult = CheckFileName(L, filename);
+	if (checkresult)
+		return checkresult;
+
+	luaL_checktype(L, 3, LUA_TFUNCTION);
+
+	if (!(strchr(mode, 'r') || strchr(mode, '+')))
+		luaL_error(L, "opennew() is only for reading, use openlocal() for writing");
+
+	AddLuaFileTransfer(filename, mode);
+
+	return 0;
+}
+
+
+static int io_openlocal (lua_State *L) {
+	FILE **pf;
+	const char *filename = luaL_checkstring(L, 1);
+	const char *mode = luaL_optstring(L, 2, "r");
+	char *realfilename;
+	luafiletransfer_t *filetransfer;
+	int checkresult;
+
+	checkresult = CheckFileName(L, filename);
+	if (checkresult)
+		return checkresult;
+
+	realfilename = va("%s" PATHSEP "%s", luafiledir, filename);
+
+	if (client && strnicmp(filename, "client/", strlen("client/")))
+		I_Error("Access denied to %s\n"
+		        "Clients can only access files stored in luafiles/client/\n",
+		        filename);
+
+	// Prevent access if the file is being downloaded
+	for (filetransfer = luafiletransfers; filetransfer; filetransfer = filetransfer->next)
+		if (!stricmp(filetransfer->filename, filename))
+			I_Error("Access denied to %s\n"
+			        "Files can't be opened while being downloaded\n",
+			        filename);
+
+	MakePathDirs(realfilename);
+
+	// Open and return the file
 	pf = newfile(L);
-	*pf = fopen(destFilename, mode);
+	*pf = fopen(realfilename, mode);
 	return (*pf == NULL) ? pushresult(L, 0, filename) : 1;
+}
+
+static int io_open (lua_State *L)
+{
+  return io_openlocal(L); // Compatibility
+}
+
+
+void Got_LuaFile(UINT8 **cp, INT32 playernum)
+{
+	FILE **pf = NULL;
+	UINT8 success = READUINT8(*cp); // The first (and only) byte indicates whether the file could be opened
+
+	if (playernum != serverplayer)
+	{
+		CONS_Alert(CONS_WARNING, M_GetText("Illegal luafile command received from %s\n"), player_names[playernum]);
+		if (server)
+			SendKick(playernum, KICK_MSG_CON_FAIL);
+		return;
+	}
+
+	if (!luafiletransfers)
+		I_Error("No Lua file transfer\n");
+
+	// Retrieve the callback and push it on the stack
+	lua_pushfstring(gL, FMT_FILECALLBACKID, luafiletransfers->id);
+	lua_gettable(gL, LUA_REGISTRYINDEX);
+
+	// Push the first argument (file handle or nil) on the stack
+	if (success)
+	{
+		pf = newfile(gL); // Create and push the file handle
+		*pf = fopen(luafiletransfers->realfilename, luafiletransfers->mode); // Open the file
+		if (!*pf)
+			I_Error("Can't open file \"%s\"\n", luafiletransfers->realfilename); // The file SHOULD exist
+	}
+	else
+		lua_pushnil(gL);
+
+	// Push the second argument (file name) on the stack
+	lua_pushstring(gL, luafiletransfers->filename);
+
+	// Call the callback
+	LUA_Call(gL, 2);
+
+	if (success)
+	{
+		// Close the file
+		if (*pf)
+		{
+			fclose(*pf);
+			*pf = NULL;
+		}
+
+		if (client)
+			remove(luafiletransfers->realfilename);
+	}
+
+	RemoveLuaFileTransfer();
+
+	if (server && luafiletransfers)
+	{
+		if (FIL_FileOK(luafiletransfers->realfilename))
+			SV_PrepareSendLuaFileToNextNode();
+		else
+		{
+			// Send a net command with 0 as its first byte to indicate the file couldn't be opened
+			success = 0;
+			SendNetXCmd(XD_LUAFILE, &success, 1);
+		}
+	}
+}
+
+
+void StoreLuaFileCallback(INT32 id)
+{
+	lua_pushfstring(gL, FMT_FILECALLBACKID, id);
+	lua_pushvalue(gL, 3); // Parameter 3 is the callback
+	lua_settable(gL, LUA_REGISTRYINDEX); // registry[callbackid] = callback
+}
+
+
+void RemoveLuaFileCallback(INT32 id)
+{
+	lua_pushfstring(gL, FMT_FILECALLBACKID, id);
+	lua_pushnil(gL);
+	lua_settable(gL, LUA_REGISTRYINDEX); // registry[callbackid] = nil
 }
 
 
@@ -219,47 +351,6 @@ static int io_tmpfile (lua_State *L) {
   FILE **pf = newfile(L);
   *pf = tmpfile();
   return (*pf == NULL) ? pushresult(L, 0, NULL) : 1;
-}
-
-
-static FILE *getiofile (lua_State *L, int findex) {
-  FILE *f;
-  lua_rawgeti(L, LUA_ENVIRONINDEX, findex);
-  f = *(FILE **)lua_touserdata(L, -1);
-  if (f == NULL)
-    luaL_error(L, "standard %s file is closed", fnames[findex - 1]);
-  return f;
-}
-
-
-static int g_iofile (lua_State *L, int f, const char *mode) {
-  if (!lua_isnoneornil(L, 1)) {
-    const char *filename = lua_tostring(L, 1);
-    if (filename) {
-      FILE **pf = newfile(L);
-      *pf = fopen(filename, mode);
-      if (*pf == NULL)
-        fileerror(L, 1, filename);
-    }
-    else {
-      tofile(L);  /* check that it's a valid file handle */
-      lua_pushvalue(L, 1);
-    }
-    lua_rawseti(L, LUA_ENVIRONINDEX, f);
-  }
-  /* return current value */
-  lua_rawgeti(L, LUA_ENVIRONINDEX, f);
-  return 1;
-}
-
-
-static int io_input (lua_State *L) {
-  return g_iofile(L, IO_INPUT, "r");
-}
-
-
-static int io_output (lua_State *L) {
-  return g_iofile(L, IO_OUTPUT, "w");
 }
 
 
@@ -277,24 +368,6 @@ static int f_lines (lua_State *L) {
   tofile(L);  /* check that it's a valid file handle */
   aux_lines(L, 1, 0);
   return 1;
-}
-
-
-static int io_lines (lua_State *L) {
-  if (lua_isnoneornil(L, 1)) {  /* no arguments? */
-    /* will iterate over default input */
-    lua_rawgeti(L, LUA_ENVIRONINDEX, IO_INPUT);
-    return f_lines(L);
-  }
-  else {
-    const char *filename = luaL_checkstring(L, 1);
-    FILE **pf = newfile(L);
-    *pf = fopen(filename, "r");
-    if (*pf == NULL)
-      fileerror(L, 1, filename);
-    aux_lines(L, lua_gettop(L), 1);
-    return 1;
-  }
 }
 
 
@@ -410,11 +483,6 @@ static int g_read (lua_State *L, FILE *f, int first) {
 }
 
 
-static int io_read (lua_State *L) {
-  return g_read(L, getiofile(L, IO_INPUT), 1);
-}
-
-
 static int f_read (lua_State *L) {
   return g_read(L, tofile(L), 2);
 }
@@ -445,6 +513,7 @@ static int io_readline (lua_State *L) {
 static int g_write (lua_State *L, FILE *f, int arg) {
   int nargs = lua_gettop(L) - 1;
   int status = 1;
+  size_t count;
   for (; nargs--; arg++) {
     if (lua_type(L, arg) == LUA_TNUMBER) {
       /* optimization: could be done exactly as for strings */
@@ -454,6 +523,7 @@ static int g_write (lua_State *L, FILE *f, int arg) {
     else {
       size_t l;
       const char *s = luaL_checklstring(L, arg, &l);
+	  count += l;
 	  if (ftell(f) + l > FILELIMIT)
 	  {
 		luaL_error(L,"write limit bypassed in file. Changes have been discarded.");
@@ -463,11 +533,6 @@ static int g_write (lua_State *L, FILE *f, int arg) {
     }
   }
   return pushresult(L, status, NULL);
-}
-
-
-static int io_write (lua_State *L) {
-  return g_write(L, getiofile(L, IO_OUTPUT), 1);
 }
 
 
@@ -503,12 +568,6 @@ static int f_setvbuf (lua_State *L) {
 }
 
 
-
-static int io_flush (lua_State *L) {
-  return pushresult(L, fflush(getiofile(L, IO_OUTPUT)) == 0, NULL);
-}
-
-
 static int f_flush (lua_State *L) {
   return pushresult(L, fflush(tofile(L)) == 0, NULL);
 }
@@ -516,15 +575,11 @@ static int f_flush (lua_State *L) {
 
 static const luaL_Reg iolib[] = {
   {"close", io_close},
-  {"flush", io_flush},
-  {"input", io_input},
-  {"lines", io_lines},
   {"open", io_open},
-  {"output", io_output},
-  {"read", io_read},
+  {"openlocal", io_openlocal},
+  {"opennew", io_opennew},
   {"tmpfile", io_tmpfile},
   {"type", io_type},
-  {"write", io_write},
   {NULL, NULL}
 };
 
@@ -585,3 +640,4 @@ LUALIB_API int luaopen_io (lua_State *L) {
   lua_pop(L, 1);  /* pop environment for default files */
   return 1;
 }
+

--- a/src/blua/liolib.c
+++ b/src/blua/liolib.c
@@ -239,10 +239,10 @@ static int io_openlocal (lua_State *L) {
 
 	realfilename = va("%s" PATHSEP "%s", luafiledir, filename);
 
-	if (client && strnicmp(filename, "client/", strlen("client/")))
+	/*(if (client && strnicmp(filename, "client/", strlen("client/")))
 		I_Error("Access denied to %s\n"
 		        "Clients can only access files stored in luafiles/client/\n",
-		        filename);
+		        filename);*/
 
 	// Prevent access if the file is being downloaded
 	for (filetransfer = luafiletransfers; filetransfer; filetransfer = filetransfer->next)

--- a/src/d_clisrv.h
+++ b/src/d_clisrv.h
@@ -57,7 +57,11 @@ typedef enum
 	PT_WILLRESENDGAMESTATE, // Hey Client, I am about to resend you the gamestate!
 	PT_CANRECEIVEGAMESTATE, // Okay Server, I'm ready to receive it, you can go ahead.
 	PT_RECEIVEDGAMESTATE,   // Thank you Server, I am ready to play again!
-	PT_BASICKEEPALIVE,// Keep the network alive during wipes, as tics aren't advanced and NetUpdate isn't called
+	PT_BASICKEEPALIVE, // Keep the network alive during wipes, as tics aren't advanced and NetUpdate isn't called
+
+	PT_SENDINGLUAFILE, // Server telling a client Lua needs to open a file
+	PT_ASKLUAFILE,     // Client telling the server they don't have the file
+	PT_HASLUAFILE,     // Client telling the server they have the file
 
 	// Add non-PT_CANFAIL packet types here to avoid breaking MS compatibility.
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1168,6 +1168,7 @@ void D_SRB2Main(void)
 			// can't use sprintf since there is %u in savegamename
 			strcatbf(savegamename, srb2home, PATHSEP);
 
+			snprintf(luafiledir, sizeof luafiledir, "%s" PATHSEP "luafiles", srb2home);
 #else
 			snprintf(srb2home, sizeof srb2home, "%s", userhome);
 			snprintf(downloaddir, sizeof downloaddir, "%s", userhome);
@@ -1178,6 +1179,8 @@ void D_SRB2Main(void)
 
 			// can't use sprintf since there is %u in savegamename
 			strcatbf(savegamename, userhome, PATHSEP);
+
+			snprintf(luafiledir, sizeof luafiledir, "%s" PATHSEP "luafiles", userhome);
 #endif
 		}
 

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -721,6 +721,8 @@ void Net_CloseConnection(INT32 node)
 
 	InitNode(&nodes[node]);
 	SV_AbortSendFiles(node);
+	if (server)
+		SV_AbortLuaFileTransfer(node);
 	I_NetFreeNodenum(node);
 #endif
 }
@@ -805,6 +807,10 @@ static const char *packettypename[NUMPACKETTYPE] =
 	"WILLRESENDGAMESTATE",
 	"CANRECEIVEGAMESTATE",
 	"RECEIVEDGAMESTATE",
+
+	"SENDINGLUAFILE",
+	"ASKLUAFILE",
+	"HASLUAFILE",
 
 	"FILEFRAGMENT",
 	"TEXTCMD",

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -429,7 +429,8 @@ const char *netxcmdnames[MAXNETXCMD - 1] =
 	"SETMOTD",
 	"SUICIDE",
 	"LUACMD",
-	"LUAVAR"
+	"LUAVAR",
+	"LUAFILE"
 };
 
 // =========================================================================
@@ -466,6 +467,7 @@ void D_RegisterServerCommands(void)
 	RegisterNetXCmd(XD_SUICIDE, Got_Suicide);
 	RegisterNetXCmd(XD_RUNSOC, Got_RunSOCcmd);
 	RegisterNetXCmd(XD_LUACMD, Got_Luacmd);
+	RegisterNetXCmd(XD_LUAFILE, Got_LuaFile);
 
 	// Remote Administration
 	COM_AddCommand("password", Command_Changepassword_f);

--- a/src/d_netcmd.h
+++ b/src/d_netcmd.h
@@ -152,6 +152,7 @@ typedef enum
 	XD_DEMOTED,     // 21
 	XD_LUACMD,      // 22
 	XD_LUAVAR,      // 23
+	XD_LUAFILE,     // 24
 	MAXNETXCMD
 } netxcmd_t;
 

--- a/src/d_netfil.c
+++ b/src/d_netfil.c
@@ -77,6 +77,7 @@ typedef struct filetx_s
 	UINT32 size; // Size of the file
 	UINT8 fileid;
 	INT32 node; // Destination
+	boolean textmode; // For files requested by Lua without the "b" option
 	struct filetx_s *next; // Next file in the list
 } filetx_t;
 
@@ -101,6 +102,10 @@ char downloaddir[512] = "DOWNLOAD";
 // for cl loading screen
 INT32 lastfilenum = -1;
 #endif
+
+luafiletransfer_t *luafiletransfers = NULL;
+boolean waitingforluafiletransfer = false;
+char luafiledir[256 + 16] = "luafiles";
 
 /** Fills a serverinfo packet with information about wad files loaded.
   *
@@ -167,6 +172,7 @@ void D_ParseFileneeded(INT32 fileneedednum_parm, UINT8 *fileneededstr)
 		fileneeded[i].file = NULL; // The file isn't open yet
 		READSTRINGN(p, fileneeded[i].filename, MAX_WADPATH); // The next bytes are the file name
 		READMEM(p, fileneeded[i].md5sum, 16); // The last 16 bytes are the file checksum
+		fileneeded[i].textmode = false;
 	}
 }
 
@@ -178,6 +184,7 @@ void CL_PrepareDownloadSaveGame(const char *tmpsave)
 	fileneeded[0].file = NULL;
 	memset(fileneeded[0].md5sum, 0, 16);
 	strcpy(fileneeded[0].filename, tmpsave);
+	fileneeded[0].textmode = false;
 }
 
 /** Checks the server to see if we CAN download all the files,
@@ -456,6 +463,163 @@ void CL_LoadServerFiles(void)
 	}
 }
 
+void AddLuaFileTransfer(const char *filename, const char *mode)
+{
+	luafiletransfer_t **prevnext; // A pointer to the "next" field of the last transfer in the list
+	luafiletransfer_t *filetransfer;
+	static INT32 id;
+
+	//CONS_Printf("AddLuaFileTransfer \"%s\"\n", filename);
+
+	// Find the last transfer in the list and set a pointer to its "next" field
+	prevnext = &luafiletransfers;
+	while (*prevnext)
+		prevnext = &((*prevnext)->next);
+
+	// Allocate file transfer information and append it to the transfer list
+	filetransfer = malloc(sizeof(luafiletransfer_t));
+	if (!filetransfer)
+		I_Error("AddLuaFileTransfer: Out of memory\n");
+	*prevnext = filetransfer;
+	filetransfer->next = NULL;
+
+	// Allocate the file name
+	filetransfer->filename = strdup(filename);
+	if (!filetransfer->filename)
+		I_Error("AddLuaFileTransfer: Out of memory\n");
+
+	// Create and allocate the real file name
+	if (server)
+		filetransfer->realfilename = strdup(va("%s" PATHSEP "%s",
+												luafiledir, filename));
+	else
+		filetransfer->realfilename = strdup(va("%s" PATHSEP "client" PATHSEP "$$$%d%d.tmp",
+												luafiledir, rand(), rand()));
+	if (!filetransfer->realfilename)
+		I_Error("AddLuaFileTransfer: Out of memory\n");
+
+	strlcpy(filetransfer->mode, mode, sizeof(filetransfer->mode));
+
+	if (server)
+	{
+		INT32 i;
+
+		// Set status to "waiting" for everyone
+		for (i = 0; i < MAXNETNODES; i++)
+			filetransfer->nodestatus[i] = LFTNS_WAITING;
+
+		if (!luafiletransfers->next) // Only if there is no transfer already going on
+		{
+			if (FIL_ReadFileOK(filetransfer->realfilename))
+				SV_PrepareSendLuaFileToNextNode();
+			else
+			{
+				// Send a net command with 0 as its first byte to indicate the file couldn't be opened
+				UINT8 success = 0;
+				SendNetXCmd(XD_LUAFILE, &success, 1);
+			}
+		}
+	}
+
+	// Store the callback so it can be called once everyone has the file
+	filetransfer->id = id;
+	StoreLuaFileCallback(id);
+	id++;
+
+	if (waitingforluafiletransfer)
+	{
+		waitingforluafiletransfer = false;
+		CL_PrepareDownloadLuaFile();
+	}
+}
+
+void SV_PrepareSendLuaFileToNextNode(void)
+{
+	INT32 i;
+	UINT8 success = 1;
+
+    // Find a client to send the file to
+	for (i = 1; i < MAXNETNODES; i++)
+		if (nodeingame[i] && luafiletransfers->nodestatus[i] == LFTNS_WAITING) // Node waiting
+		{
+			// Tell the client we're about to send them the file
+			netbuffer->packettype = PT_SENDINGLUAFILE;
+			if (!HSendPacket(i, true, 0, 0))
+				I_Error("Failed to send a PT_SENDINGLUAFILE packet\n"); // !!! Todo: Handle failure a bit better lol
+
+			luafiletransfers->nodestatus[i] = LFTNS_ASKED;
+
+			return;
+		}
+
+	// No client found, everyone has the file
+	// Send a net command with 1 as its first byte to indicate the file could be opened
+	SendNetXCmd(XD_LUAFILE, &success, 1);
+}
+
+void SV_HandleLuaFileSent(UINT8 node)
+{
+	luafiletransfers->nodestatus[node] = LFTNS_SENT;
+	SV_PrepareSendLuaFileToNextNode();
+}
+
+void RemoveLuaFileTransfer(void)
+{
+	luafiletransfer_t *filetransfer = luafiletransfers;
+
+	RemoveLuaFileCallback(filetransfer->id);
+
+	luafiletransfers = filetransfer->next;
+
+	free(filetransfer->filename);
+	free(filetransfer->realfilename);
+	free(filetransfer);
+}
+
+void RemoveAllLuaFileTransfers(void)
+{
+	while (luafiletransfers)
+		RemoveLuaFileTransfer();
+}
+
+void SV_AbortLuaFileTransfer(INT32 node)
+{
+	if (luafiletransfers
+	&& (luafiletransfers->nodestatus[node] == LFTNS_ASKED
+	||  luafiletransfers->nodestatus[node] == LFTNS_SENDING))
+	{
+		luafiletransfers->nodestatus[node] = LFTNS_WAITING;
+		SV_PrepareSendLuaFileToNextNode();
+	}
+}
+
+void CL_PrepareDownloadLuaFile(void)
+{
+	// If there is no transfer in the list, this normally means the server
+	// called io.open before us, so we have to wait until we call it too
+	if (!luafiletransfers)
+	{
+		waitingforluafiletransfer = true;
+		return;
+	}
+
+	// Tell the server we are ready to receive the file
+	netbuffer->packettype = PT_ASKLUAFILE;
+	HSendPacket(servernode, true, 0, 0);
+
+	fileneedednum = 1;
+	fileneeded[0].status = FS_REQUESTED;
+	fileneeded[0].totalsize = UINT32_MAX;
+	fileneeded[0].file = NULL;
+	memset(fileneeded[0].md5sum, 0, 16);
+	strcpy(fileneeded[0].filename, luafiletransfers->realfilename);
+	fileneeded[0].textmode = !strchr(luafiletransfers->mode, 'b');
+
+	// Make sure all directories in the file path exist
+	MakePathDirs(fileneeded[0].filename);
+}
+
+
 // Number of files to send
 // Little optimization to quickly test if there is a file in the queue
 static INT32 filestosend = 0;
@@ -466,6 +630,7 @@ static INT32 filestosend = 0;
   * \param filename The file to send
   * \param fileid ???
   * \sa SV_SendRam
+  * \sa SV_SendLuaFile
   *
   */
 static boolean SV_SendFile(INT32 node, const char *filename, UINT8 fileid)
@@ -556,6 +721,7 @@ static boolean SV_SendFile(INT32 node, const char *filename, UINT8 fileid)
   * \param freemethod How to free the block after it has been sent
   * \param fileid ???
   * \sa SV_SendFile
+  * \sa SV_SendLuaFile
   *
   */
 void SV_SendRam(INT32 node, void *data, size_t size, freemethod_t freemethod, UINT8 fileid)
@@ -585,6 +751,55 @@ void SV_SendRam(INT32 node, void *data, size_t size, freemethod_t freemethod, UI
 	DEBFILE(va("Sending ram %p(size:%u) to %d (id=%u)\n",p->id.ram,p->size,node,fileid));
 
 	filestosend++;
+}
+
+/** Adds a file requested by Lua to the file list for a node
+  *
+  * \param node The node to send the file to
+  * \param filename The file to send
+  * \sa SV_SendFile
+  * \sa SV_SendRam
+  *
+  */
+boolean SV_SendLuaFile(INT32 node, const char *filename, boolean textmode)
+{
+	filetx_t **q; // A pointer to the "next" field of the last file in the list
+	filetx_t *p; // The new file request
+	//INT32 i;
+	//char wadfilename[MAX_WADPATH];
+
+	luafiletransfers->nodestatus[node] = LFTNS_SENDING;
+
+	// Find the last file in the list and set a pointer to its "next" field
+	q = &transfer[node].txlist;
+	while (*q)
+		q = &((*q)->next);
+
+	// Allocate a file request and append it to the file list
+	p = *q = (filetx_t *)malloc(sizeof (filetx_t));
+	if (!p)
+		I_Error("SV_SendLuaFile: No more memory\n");
+
+	// Initialise with zeros
+	memset(p, 0, sizeof (filetx_t));
+
+	// Allocate the file name
+	p->id.filename = (char *)malloc(MAX_WADPATH); // !!!
+	if (!p->id.filename)
+		I_Error("SV_SendLuaFile: No more memory\n");
+
+	// Set the file name and get rid of the path
+	strlcpy(p->id.filename, filename, MAX_WADPATH); // !!!
+	//nameonly(p->id.filename);
+
+	// Open in text mode if required by the Lua script
+	p->textmode = textmode;
+
+	DEBFILE(va("Sending Lua file %s to %d\n", filename, node));
+	p->ram = SF_FILE; // It's a file, we need to close it and free its name once we're done sending it
+	p->next = NULL; // End of list
+	filestosend++;
+	return true;
 }
 
 /** Stops sending a file for a node, and removes the file request from the list,
@@ -692,7 +907,7 @@ void SV_FileSendTicker(void)
 				long filesize;
 
 				transfer[i].currentfile =
-					fopen(f->id.filename, "rb");
+					fopen(f->id.filename, f->textmode ? "r" : "rb");
 
 				if (!transfer[i].currentfile)
 					I_Error("File %s does not exist",
@@ -723,11 +938,20 @@ void SV_FileSendTicker(void)
 			size = f->size-transfer[i].position;
 		if (ram)
 			M_Memcpy(p->data, &f->id.ram[transfer[i].position], size);
-		else if (fread(p->data, 1, size, transfer[i].currentfile) != size)
-			I_Error("SV_FileSendTicker: can't read %s byte on %s at %d because %s", sizeu1(size), f->id.filename, transfer[i].position, M_FileError(transfer[i].currentfile));
+		else
+		{
+			size_t n = fread(p->data, 1, size, transfer[i].currentfile);
+			if (n != size) // Either an error or Windows turning CR-LF into LF
+			{
+				if (f->textmode && feof(transfer[i].currentfile))
+                    size = n;
+				else if (fread(p->data, 1, size, transfer[i].currentfile) != size)
+					I_Error("SV_FileSendTicker: can't read %s byte on %s at %d because %s", sizeu1(size), f->id.filename, transfer[i].position, M_FileError(transfer[i].currentfile));
+			}
+		}
 		p->position = LONG(transfer[i].position);
 		// Put flag so receiver knows the total size
-		if (transfer[i].position + size == f->size)
+		if (transfer[i].position + size == f->size || (f->textmode && feof(transfer[i].currentfile)))
 			p->position |= LONG(0x80000000);
 		p->fileid = f->fileid;
 		p->size = SHORT((UINT16)size);
@@ -736,7 +960,7 @@ void SV_FileSendTicker(void)
 		if (HSendPacket(i, true, 0, FILETXHEADER + size)) // Reliable SEND
 		{ // Success
 			transfer[i].position = (UINT32)(transfer[i].position + size);
-			if (transfer[i].position == f->size) // Finish?
+			if (transfer[i].position == f->size || (f->textmode && feof(transfer[i].currentfile))) // Finish?
 				SV_EndFileSend(i);
 		}
 		else
@@ -782,7 +1006,7 @@ void Got_Filetxpak(void)
 	{
 		if (file->file)
 			I_Error("Got_Filetxpak: already open file\n");
-		file->file = fopen(filename, "wb");
+		file->file = fopen(filename, file->textmode ? "w" : "wb");
 		if (!file->file)
 			I_Error("Can't create file %s: %s", filename, strerror(errno));
 		CONS_Printf("\r%s...\n",filename);
@@ -803,7 +1027,7 @@ void Got_Filetxpak(void)
 		}
 		// We can receive packet in the wrong order, anyway all os support gaped file
 		fseek(file->file, pos, SEEK_SET);
-		if (fwrite(netbuffer->u.filetxpak.data,size,1,file->file) != 1)
+		if (size && fwrite(netbuffer->u.filetxpak.data,size,1,file->file) != 1)
 			I_Error("Can't write to %s: %s\n",filename, M_FileError(file->file));
 		file->currentsize += size;
 
@@ -815,6 +1039,13 @@ void Got_Filetxpak(void)
 			file->status = FS_FOUND;
 			CONS_Printf(M_GetText("Downloading %s...(done)\n"),
 				filename);
+			
+			if (luafiletransfers)
+			{
+				// Tell the server we have received the file
+				netbuffer->packettype = PT_HASLUAFILE;
+				HSendPacket(servernode, true, 0, 0);
+			}
 		}
 	}
 	else

--- a/src/d_netfil.h
+++ b/src/d_netfil.h
@@ -14,6 +14,7 @@
 #define __D_NETFIL__
 
 #include "w_wad.h"
+#include "d_net.h"
 
 typedef enum
 {
@@ -43,6 +44,7 @@ typedef struct
 	UINT32 currentsize;
 	UINT32 totalsize;
 	filestatus_t status; // The value returned by recsearch
+	boolean textmode; // For files requested by Lua without the "b" option
 } fileneeded_t;
 
 extern INT32 fileneedednum;
@@ -69,6 +71,42 @@ boolean SV_SendingFile(INT32 node);
 boolean CL_CheckDownloadable(void);
 boolean CL_SendRequestFile(void);
 boolean Got_RequestFilePak(INT32 node);
+
+typedef enum
+{
+	LFTNS_WAITING, // This node is waiting for the server to send the file
+	LFTNS_ASKED, // The server has told the node they're ready to send the file
+	LFTNS_SENDING, // The server is sending the file to this node
+	LFTNS_SENT // The node already has the file
+} luafiletransfernodestatus_t;
+
+typedef struct luafiletransfer_s
+{
+	char *filename;
+	char *realfilename;
+	char mode[4]; // rb+/wb+/ab+ + null character
+	INT32 id; // Callback ID
+	luafiletransfernodestatus_t nodestatus[MAXNETNODES];
+	struct luafiletransfer_s *next;
+} luafiletransfer_t;
+
+extern luafiletransfer_t *luafiletransfers;
+extern boolean waitingforluafiletransfer;
+extern char luafiledir[256 + 16];
+
+void AddLuaFileTransfer(const char *filename, const char *mode);
+void SV_PrepareSendLuaFileToNextNode(void);
+boolean SV_SendLuaFile(INT32 node, const char *filename, boolean textmode);
+void SV_PrepareSendLuaFile(const char *filename);
+void SV_HandleLuaFileSent(UINT8 node);
+void RemoveLuaFileTransfer(void);
+void RemoveAllLuaFileTransfers(void);
+void SV_AbortLuaFileTransfer(INT32 node);
+void CL_PrepareDownloadLuaFile(void);
+void Got_LuaFile(UINT8 **cp, INT32 playernum);
+void StoreLuaFileCallback(INT32 id);
+void RemoveLuaFileCallback(INT32 id);
+void MakePathDirs(char *path);
 
 void SV_AbortSendFiles(INT32 node);
 void CloseNetFile(void);

--- a/src/lua_baselib.c
+++ b/src/lua_baselib.c
@@ -24,6 +24,7 @@
 #include "console.h"
 #include "d_netcmd.h" // IsPlayerAdmin
 #include "m_menu.h" // M_CheckColor, M_GetColorNext, M_GetColorPrev
+#include "r_draw.h"
 
 #include "lua_script.h"
 #include "lua_libs.h"
@@ -1805,6 +1806,36 @@ static int lib_rTextureNumForName(lua_State *L)
 	return 1;
 }
 
+// R_DRAW
+////////////
+static int lib_rGetColorByName(lua_State *L)
+{
+	const char* colorname = luaL_checkstring(L, 1);
+	//HUDSAFE
+	lua_pushinteger(L, R_GetColorByName(colorname));
+	return 1;
+}
+
+static int lib_rGetSuperColorByName(lua_State *L)
+{
+	const char* colorname = luaL_checkstring(L, 1);
+	//HUDSAFE
+	lua_pushinteger(L, R_GetSuperColorByName(colorname));
+	return 1;
+}
+
+// Lua exclusive function, returns the name of a color from the SKINCOLOR_ constant.
+// SKINCOLOR_GREEN > "Green" for example
+static int lib_rGetNameByColor(lua_State *L)
+{
+	UINT16 colornum = (UINT16)luaL_checkinteger(L, 1);
+	if (!colornum || colornum >= numskincolors)
+		return luaL_error(L, "skincolor %d out of range (1 - %d).", colornum, numskincolors-1);
+	lua_pushstring(L, skincolors[colornum].name);
+	return 1;
+}
+
+
 // S_SOUND
 ////////////
 
@@ -2427,6 +2458,11 @@ static luaL_Reg lib[] = {
 	// r_data
 	{"R_CheckTextureNumForName",lib_rCheckTextureNumForName},
 	{"R_TextureNumForName",lib_rTextureNumForName},
+
+	// r_draw
+	{"R_GetColorByName", lib_rGetColorByName},
+	{"R_GetSuperColorByName", lib_rGetSuperColorByName},
+	{"R_GetNameByColor", lib_rGetNameByColor},
 
 	// s_sound
 	{"S_StartSound",lib_sStartSound},


### PR DESCRIPTION
Backports the Lua I/O library from 2.2 which supports sending files over lua with `io.opennew` and `io.open` is a wrapper for `io.openlocal`  (to keep compatibilty with 2.1 mods that used I/O) as well as a bunch of other changes. I've made an edited version of `sendcolor.lua` that supports 2.1 and it works functionally the exact same as the 2.2 version (save as .lua)

[sendcolor-v7-21edit.lua.txt](https://github.com/user-attachments/files/21244097/sendcolor-v7-21edit.lua.txt)
