### PR TITLE
Fix mobjinfo_t to allow custom variables again

### DIFF
--- a/src/lua_infolib.c
+++ b/src/lua_infolib.c
@@ -615,7 +615,7 @@ static int mobjinfo_fields_ref = LUA_NOREF;
 static int mobjinfo_get(lua_State *L)
 {
 	mobjinfo_t *info = *((mobjinfo_t **)luaL_checkudata(L, 1, META_MOBJINFO));
-	enum mobjinfo_e field = luaL_checkoption(L, 2, mobjinfo_opt[0], mobjinfo_opt);
+	enum mobjinfo_e field = Lua_optoption(L, 2, mobjinfo_doomednum, mobjinfo_fields_ref);
 
 	I_Assert(info != NULL);
 	I_Assert(info >= mobjinfo);


### PR DESCRIPTION
Fixed a regression introduced by 82558aad3ab90e39676a27f25dd1421efe86f97a since 2.1.28 while LJ Sonic was trying to run one of it's old 2.1 addons in Legacy where it makes `mobjinfo_get` to use `luaL_checkoption` instead of `Lua_optoption` for checking is the field is valid or not.

While both do the same, the former throws an error and avoids the custom Lua variable code to be called at all, while the later returns without an error and the custom Lua variable code gets called which returns if the specified variable exists it returns it's value or if the specified variable doesn't exists it simply returns nil.

This however, only happens when getting the variable while setting it works as intended.