### PR TITLE
Fix hyperwalls because TAS's suck and so does PAS and so does speedrunning in general please play your games slowly RAHHHHHH

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2387,7 +2387,7 @@ static void P_HitSlideLine(line_t *ld)
 	lineangle >>= ANGLETOFINESHIFT;
 	deltaangle >>= ANGLETOFINESHIFT;
 
-	movelen = P_AproxDistance(tmxmove, tmymove);
+	movelen = R_PointToDist2(0, 0, tmxmove, tmymove);
 	newlen = FixedMul(movelen, FINECOSINE(deltaangle));
 
 	tmxmove = FixedMul(newlen, FINECOSINE(lineangle));


### PR DESCRIPTION
This is not vanilla 2.1.
The fix from https://github.com/srb2-preservation/srb2-legacy/pull/5 was not reverted because it breaks the DSZ2 waterfall, making it
significantly harder to complete the stage as Sonic. (Unless you grab
the whirlwind shield and jump over it, but that's  intuitive, it's
alone our place to decide. I say "was" because the revert for it vanished in https://github.com/srb2-preservation/srb2-legacy/pull/114 and that's a good thing)
The hyperwall "fix" will be added because it will be impossible to
compete with speedruns done on 2.1.25. I want to force people to
use older versions of 2.1/Legacy for speedrunning because that defeats the
**entire** purpose of SRB2 Legacy. Keep in mind, Refrag did a run of 2.1
MORE THAN TWO MONTHS AGO that uses hyperwalls (https://youtu.be/uxHyxf0NjO4). They
will be staying.
Anything relating to movement/physics will be staying not vanilla, no
exceptions.