### PR TITLE
Lua titlescreen and titlecard HUD Hooks

### DIFF
--- a/src/dehacked.c
+++ b/src/dehacked.c
@@ -2957,6 +2957,10 @@ static void readmaincfg(MYFILE *f)
 				looptitle = (value || word2[0] == 'T' || word2[0] == 'Y');
 				titlechanged = true;
 			}
+			else if (fastcmp(word, "HIDETITLEPICS"))
+			{
+				hidetitlepics = (boolean)(value || word2[0] == 'T' || word2[0] == 'Y');
+			}
 			else if (fastcmp(word, "TITLESCROLLSPEED"))
 			{
 

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -33,6 +33,8 @@
 #include "y_inter.h"
 #include "m_cond.h"
 
+#include "lua_hud.h"
+
 // Stage of animation:
 // 0 = text, 1 = art screen
 static INT32 finalecount;
@@ -1509,6 +1511,10 @@ void F_TitleScreenDrawer(void)
 	if (!ttwing || (gamestate != GS_TITLESCREEN && gamestate != GS_WAITINGPLAYERS))
 		return;
 
+	// rei|miru: use title pics?
+	if (hidetitlepics)
+		goto luahook;
+
 	V_DrawScaledPatch(30, 14, 0, ttwing);
 
 	if (finalecount < 57)
@@ -1545,6 +1551,9 @@ void F_TitleScreenDrawer(void)
 	}
 
 	V_DrawScaledPatch(48, 142, 0,ttbanner);
+
+luahook:
+	LUAh_TitleHUD();
 }
 
 // (no longer) De-Demo'd Title Screen

--- a/src/f_finale.h
+++ b/src/f_finale.h
@@ -64,6 +64,7 @@ void F_StartWaitingPlayers(void);
 void F_WaitingPlayersTicker(void);
 void F_WaitingPlayersDrawer(void);
 
+extern boolean hidetitlepics;
 extern INT32 titlescrollspeed;
 
 //

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -128,6 +128,8 @@ INT16 spstage_start, spmarathon_start;
 INT16 sstage_start;
 INT16 sstage_end;
 
+boolean hidetitlepics = false;
+
 boolean looptitle = false;
 boolean useNightsSS = false;
 

--- a/src/lua_hud.h
+++ b/src/lua_hud.h
@@ -49,5 +49,6 @@ boolean LUA_HudEnabled(enum hud option);
 
 void LUAh_GameHUD(player_t *stplayr, huddrawlist_h list);
 void LUAh_ScoresHUD(huddrawlist_h list);
+void LUAh_TitleHUD(void);
 
 #endif // __LUA_HUD_H__

--- a/src/lua_hud.h
+++ b/src/lua_hud.h
@@ -50,5 +50,6 @@ boolean LUA_HudEnabled(enum hud option);
 void LUAh_GameHUD(player_t *stplayr, huddrawlist_h list);
 void LUAh_ScoresHUD(huddrawlist_h list);
 void LUAh_TitleHUD(void);
+void LUAh_TitleCardHUD(void);
 
 #endif // __LUA_HUD_H__

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -95,11 +95,13 @@ static int patch_fields_ref = LUA_NOREF;
 
 enum hudhook {
 	hudhook_game = 0,
-	hudhook_scores
+	hudhook_scores,
+	hudhook_title
 };
 static const char *const hudhook_opt[] = {
 	"game",
 	"scores",
+	"title",
 	NULL};
 
 // alignment types for v.drawString
@@ -1050,6 +1052,9 @@ int LUA_HudLib(lua_State *L)
 
 		lua_newtable(L);
 		lua_rawseti(L, -2, 3); // HUD[2] = scores rendering functions array
+
+		lua_newtable(L);
+		lua_rawseti(L, -2, 4); // HUD[3] = title rendering functions array
 	lua_setfield(L, LUA_REGISTRYINDEX, "HUD");
 
 	luaL_newmetatable(L, META_HUDINFO);
@@ -1158,6 +1163,31 @@ void LUAh_ScoresHUD(huddrawlist_h list)
 	lua_getfield(gL, LUA_REGISTRYINDEX, "HUD");
 	I_Assert(lua_istable(gL, -1));
 	lua_rawgeti(gL, -1, 3); // HUD[3] = rendering funcs
+	I_Assert(lua_istable(gL, -1));
+
+	lua_rawgeti(gL, -2, 1); // HUD[1] = lib_draw
+	I_Assert(lua_istable(gL, -1));
+	lua_remove(gL, -3); // pop HUD
+	lua_pushnil(gL);
+	while (lua_next(gL, -3) != 0) {
+		lua_pushvalue(gL, -3); // graphics library (HUD[1])
+		LUA_Call(gL, 1);
+	}
+	lua_pop(gL, -1);
+	hud_running = false;
+}
+
+void LUAh_TitleHUD(void)
+{
+	if (!gL || !(hudAvailable & (1<<hudhook_title)))
+		return;
+
+	hud_running = true;
+	lua_pop(gL, -1);
+
+	lua_getfield(gL, LUA_REGISTRYINDEX, "HUD");
+	I_Assert(lua_istable(gL, -1));
+	lua_rawgeti(gL, -1, 2+hudhook_title); // HUD[5] = rendering funcs
 	I_Assert(lua_istable(gL, -1));
 
 	lua_rawgeti(gL, -2, 1); // HUD[1] = lib_draw

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -96,12 +96,14 @@ static int patch_fields_ref = LUA_NOREF;
 enum hudhook {
 	hudhook_game = 0,
 	hudhook_scores,
-	hudhook_title
+	hudhook_title,
+	hudhook_titlecard
 };
 static const char *const hudhook_opt[] = {
 	"game",
 	"scores",
 	"title",
+	"titlecard",
 	NULL};
 
 // alignment types for v.drawString
@@ -1055,6 +1057,9 @@ int LUA_HudLib(lua_State *L)
 
 		lua_newtable(L);
 		lua_rawseti(L, -2, 4); // HUD[3] = title rendering functions array
+
+		lua_newtable(L);
+		lua_rawseti(L, -2, 5); // HUD[4] = title card rendering functions array
 	lua_setfield(L, LUA_REGISTRYINDEX, "HUD");
 
 	luaL_newmetatable(L, META_HUDINFO);
@@ -1188,6 +1193,31 @@ void LUAh_TitleHUD(void)
 	lua_getfield(gL, LUA_REGISTRYINDEX, "HUD");
 	I_Assert(lua_istable(gL, -1));
 	lua_rawgeti(gL, -1, 2+hudhook_title); // HUD[5] = rendering funcs
+	I_Assert(lua_istable(gL, -1));
+
+	lua_rawgeti(gL, -2, 1); // HUD[1] = lib_draw
+	I_Assert(lua_istable(gL, -1));
+	lua_remove(gL, -3); // pop HUD
+	lua_pushnil(gL);
+	while (lua_next(gL, -3) != 0) {
+		lua_pushvalue(gL, -3); // graphics library (HUD[1])
+		LUA_Call(gL, 1);
+	}
+	lua_pop(gL, -1);
+	hud_running = false;
+}
+
+void LUAh_TitleCardHUD(void)
+{
+	if (!gL || !(hudAvailable & (1<<hudhook_titlecard)))
+		return;
+
+	hud_running = true;
+	lua_pop(gL, -1);
+
+	lua_getfield(gL, LUA_REGISTRYINDEX, "HUD");
+	I_Assert(lua_istable(gL, -1));
+	lua_rawgeti(gL, -1, 2+hudhook_titlecard); // HUD[5] = rendering funcs
 	I_Assert(lua_istable(gL, -1));
 
 	lua_rawgeti(gL, -2, 1); // HUD[1] = lib_draw

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -967,6 +967,9 @@ static void ST_drawLevelTitle(void)
 	INT32 lvlttly;
 	INT32 zoney;
 
+	if (!LUA_HudEnabled(hud_stagetitle))
+		goto luahook;
+
 	if (!(timeinmap > 2 && timeinmap-3 < 110))
 		return;
 
@@ -1013,6 +1016,9 @@ static void ST_drawLevelTitle(void)
 
 	if (lvlttly+48 < 200)
 		V_DrawCenteredString(subttlxpos, lvlttly+48, V_ALLOWLOWERCASE, subttl);
+
+luahook:
+	LUAh_TitleCardHUD();
 }
 
 static void ST_drawFirstPersonHUD(void)


### PR DESCRIPTION
adds 2 hud hooks from 2.2:
1- Title: runs on the titlescreen if `HIDETITLEPICS = 1` is defined in MAINCFG (soc)
2- Titlecard: runs on the titlecard (see commit description)

example:
<img width="384" height="216" alt="srb20103" src="https://github.com/user-attachments/assets/f0b80430-73a6-4f80-a2ec-56ab08ca84a7" />

[newhudhooks.pk3](https://file.garden/aSlhXYcph2OchoUk/newhudhooks.pk3)
(titlescreen assets taken from MRCE)



