### PR TITLE
Native SRB2 home and WAD directory paths (port from dsda-doom)

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1192,11 +1192,11 @@ void D_SRB2Main(void)
 			if (M_CheckParm("-workdir") && M_IsNextParm())
 				snprintf(srb2home, sizeof srb2home, "%s", M_GetNextParm());
 			else
-#if defined(DEFAULTDIR) && !defined(__ANDROID__)
-				snprintf(srb2home, sizeof srb2home, "%s" PATHSEP DEFAULTDIR, userhome);
-#else // DEFAULTDIR
+#ifdef NATIVEDIR
+				snprintf(srb2home, sizeof srb2home, "%s", I_ConfigDir());
+#else
 				snprintf(srb2home, sizeof srb2home, "%s", userhome);
-#endif // DEFAULTDIR
+#endif
 			snprintf(downloaddir, sizeof downloaddir, "%s" PATHSEP "DOWNLOAD", srb2home);
 			if (dedicated)
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP "d"CONFIGFILENAME, srb2home);

--- a/src/dedicated/i_main.c
+++ b/src/dedicated/i_main.c
@@ -62,7 +62,9 @@ typedef BOOL (WINAPI *p_IsDebuggerPresent)(VOID);
 static void InitLogging(void)
 {
 	const char *homedir = NULL;
+#ifdef NATIVEDIR
 	const char *logdir = NULL;
+#endif
 	time_t my_time;
 	struct tm * timeinfo;
 	const char *format;
@@ -74,8 +76,6 @@ static void InitLogging(void)
 #endif
 
 	homedir = D_Home();
-	if (homedir)
-		logdir = I_ConfigDir();
 
 	my_time = time(NULL);
 	timeinfo = localtime(&my_time);
@@ -111,6 +111,7 @@ static void InitLogging(void)
 #ifdef NATIVEDIR
 		if (homedir)
 		{
+			logdir = I_ConfigDir();
 			left = snprintf(logfilename, sizeof logfilename,
 					"%s"PATHSEP"%s"PATHSEP, logdir, reldir);
 		}
@@ -126,7 +127,7 @@ static void InitLogging(void)
 	}
 
 	M_MkdirEachUntil(logfilename,
-			M_PathParts(logdir) - 1,
+			M_PathParts(homedir) - 1,
 			M_PathParts(logfilename) - 1, 0755);
 
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)

--- a/src/dedicated/i_main.c
+++ b/src/dedicated/i_main.c
@@ -61,6 +61,7 @@ typedef BOOL (WINAPI *p_IsDebuggerPresent)(VOID);
 #ifdef LOGMESSAGES
 static void InitLogging(void)
 {
+	const char *homedir = NULL;
 	const char *logdir = NULL;
 	time_t my_time;
 	struct tm * timeinfo;
@@ -72,7 +73,9 @@ static void InitLogging(void)
 	const char *link;
 #endif
 
-	logdir = D_Home();
+	homedir = D_Home();
+	if (homedir)
+		logdir = I_ConfigDir();
 
 	my_time = time(NULL);
 	timeinfo = localtime(&my_time);
@@ -105,14 +108,14 @@ static void InitLogging(void)
 					"%s"PATHSEP, reldir);
 		}
 		else
-#ifdef DEFAULTDIR
-		if (logdir)
+#ifdef NATIVEDIR
+		if (homedir)
 		{
 			left = snprintf(logfilename, sizeof logfilename,
-					"%s"PATHSEP DEFAULTDIR PATHSEP"%s"PATHSEP, logdir, reldir);
+					"%s"PATHSEP"%s"PATHSEP, logdir, reldir);
 		}
 		else
-#endif/*DEFAULTDIR*/
+#endif/*NATIVEDIR*/
 		{
 			left = snprintf(logfilename, sizeof logfilename,
 					"."PATHSEP"%s"PATHSEP, reldir);
@@ -128,11 +131,11 @@ static void InitLogging(void)
 
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
 	logstream = fopen(logfilename, "w");
-#ifdef DEFAULTDIR
-	if (logdir)
-		link = va("%s/"DEFAULTDIR"/latest-log.txt", logdir);
+#ifdef NATIVEDIR
+	if (homedir)
+		link = va("%s/latest-log.txt", logdir);
 	else
-#endif/*DEFAULTDIR*/
+#endif/*NATIVEDIR*/
 		link = "latest-log.txt";
 	unlink(link);
 	if (symlink(logfilename, link) == -1)

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -1755,6 +1755,7 @@ static boolean isWadPathOk(const char *path)
 	return false;
 }
 
+#ifdef NATIVEDIR
 static void pathonly(char *s)
 {
 	size_t j;
@@ -1798,6 +1799,7 @@ static const char *searchWad(const char *searchDir)
 	}
 	return NULL;
 }
+#endif
 
 /**	\brief go through all possible paths and look for srb2.srb
 
@@ -1806,7 +1808,9 @@ static const char *searchWad(const char *searchDir)
 static const char *locateWad(void)
 {
 	const char *envstr;
+#ifdef NATIVEDIR
 	const char *WadPath;
+#endif
 
 	// SRB2WADDIR environment variable has been renamed to SRB2LEGACYWADDIR to prevent conflicts with 2.2+.
 	I_OutputMsg("SRB2LEGACYWADDIR");

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -118,22 +118,6 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #include <errno.h>
 #endif
 
-// Locations for searching the srb2.srb
-#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
-#define DEFAULTWADLOCATION1 "/usr/local/share/games/SRB2legacy"
-#define DEFAULTWADLOCATION2 "/usr/local/games/SRB2legacy"
-#define DEFAULTWADLOCATION3 "/usr/share/games/SRB2legacy"
-#define DEFAULTWADLOCATION4 "/usr/games/SRB2legacy"
-#define DEFAULTSEARCHPATH1 "/usr/local/games"
-#define DEFAULTSEARCHPATH2 "/usr/games"
-#define DEFAULTSEARCHPATH3 "/usr/local"
-#elif defined (_WIN32)
-#define DEFAULTWADLOCATION1 "c:\\games\\srb2legacy"
-#define DEFAULTWADLOCATION2 "\\games\\srb2legacy"
-#define DEFAULTSEARCHPATH1 "c:\\games"
-#define DEFAULTSEARCHPATH2 "\\games"
-#endif
-
 /**	\brief WAD file to look for
 */
 #define WADKEYWORD1 "srb2.srb"
@@ -1685,6 +1669,15 @@ const char *I_GetXDGDataHome(const char *userhome)
 }
 #endif
 
+static const char *I_GetXDGDataDirs(void)
+{
+	const char *datadirs = I_GetEnv("XDG_DATA_DIRS");
+
+	if (!datadirs || !*datadirs)
+		return "/usr/local/share/:/usr/share/";
+	return datadirs;
+}
+
 //
 // I_ConfigDir
 // from dsda-doom
@@ -1846,51 +1839,41 @@ static const char *locateWad(void)
 	}
 #endif
 
-	// examine default dirs
-#ifdef DEFAULTWADLOCATION1
-	I_OutputMsg(","DEFAULTWADLOCATION1);
-	strcpy(returnWadPath, DEFAULTWADLOCATION1);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION2
-	I_OutputMsg(","DEFAULTWADLOCATION2);
-	strcpy(returnWadPath, DEFAULTWADLOCATION2);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION3
-	I_OutputMsg(","DEFAULTWADLOCATION3);
-	strcpy(returnWadPath, DEFAULTWADLOCATION3);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION4
-	I_OutputMsg(","DEFAULTWADLOCATION4);
-	strcpy(returnWadPath, DEFAULTWADLOCATION4);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION5
-	I_OutputMsg(","DEFAULTWADLOCATION5);
-	strcpy(returnWadPath, DEFAULTWADLOCATION5);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION6
-	I_OutputMsg(","DEFAULTWADLOCATION6);
-	strcpy(returnWadPath, DEFAULTWADLOCATION6);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION7
-	I_OutputMsg(","DEFAULTWADLOCATION7);
-	strcpy(returnWadPath, DEFAULTWADLOCATION7);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifndef NOHOME
 #ifdef NATIVEDIR
+	// examine $XDG_DATA_DIRS/games/srb2-legacy and $XDG_DATA_DIRS/srb2-legacy
+	// by default this includes:
+	// - /usr/local/share/games/srb2-legacy
+	// - /usr/share/games/srb2-legacy
+	// - /usr/local/share/srb2-legacy
+	// - /usr/share/srb2-legacy
+	char *ptr, *slash, *datadirs = strdup(I_GetXDGDataDirs());
+
+	ptr = strtok(datadirs, ":");
+	while (ptr)
+	{
+		slash = ptr[strlen(ptr)-1] != '/' ? "/" : "";
+
+		I_OutputMsg(",%s%sgames/srb2-legacy", ptr, slash);
+		snprintf(returnWadPath, sizeof(returnWadPath), "%s%sgames/srb2-legacy", ptr, slash);
+		if (isWadPathOk(returnWadPath))
+		{
+			free(datadirs);
+			return returnWadPath;
+		}
+
+		I_OutputMsg(",%s%ssrb2-legacy", ptr, slash);
+		snprintf(returnWadPath, sizeof(returnWadPath), "%s%ssrb2-legacy", ptr, slash);
+		if (isWadPathOk(returnWadPath))
+		{
+			free(datadirs);
+			return returnWadPath;
+		}
+
+		ptr = strtok(NULL, ":");
+	}
+	free(datadirs);
+
+#ifndef NOHOME
 	// find in config dir
 	envstr = I_ConfigDir();
 	I_OutputMsg(",%s", envstr);
@@ -1902,27 +1885,7 @@ static const char *locateWad(void)
 	}
 #endif
 #endif
-#ifdef DEFAULTSEARCHPATH1
-	// find in /usr/local
-	I_OutputMsg(", in:"DEFAULTSEARCHPATH1);
-	WadPath = searchWad(DEFAULTSEARCHPATH1);
-	if (WadPath)
-		return WadPath;
-#endif
-#ifdef DEFAULTSEARCHPATH2
-	// find in /usr/games
-	I_OutputMsg(", in:"DEFAULTSEARCHPATH2);
-	WadPath = searchWad(DEFAULTSEARCHPATH2);
-	if (WadPath)
-		return WadPath;
-#endif
-#ifdef DEFAULTSEARCHPATH3
-	// find in ???
-	I_OutputMsg(", in:"DEFAULTSEARCHPATH3);
-	WadPath = searchWad(DEFAULTSEARCHPATH3);
-	if (WadPath)
-		return WadPath;
-#endif
+
 	// if nothing was found
 	return NULL;
 }

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -1657,6 +1657,72 @@ const char *I_ClipboardPaste(void)
 	return NULL;
 }
 
+#ifdef NATIVEDIR
+#ifndef __APPLE__
+// Reference for XDG directories:
+// <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+// from dsda-doom
+const char *I_GetXDGDataHome(const char *userhome)
+{
+	static char *datahome = 0;
+
+	if (!datahome)
+	{
+		const char *xdgdatahome = I_GetEnv("XDG_DATA_HOME");
+
+		if (!xdgdatahome || !*xdgdatahome)
+		{
+			size_t datahomesize = strlen(userhome) + strlen("/.local/share") + 1;
+			datahome = malloc(datahomesize);
+			snprintf(datahome, datahomesize, "%s%s%s", userhome, userhome[strlen(userhome)-1] != '/' ? "/" : "", ".local/share");
+		}
+		else
+		{
+			datahome = strdup(xdgdatahome);
+		}
+	}
+	return datahome;
+}
+#endif
+
+//
+// I_ConfigDir
+// from dsda-doom
+//
+const char *I_ConfigDir()
+{
+	static char *base = NULL;
+
+	if (!base)
+	{
+		const char *home = D_Home();
+
+		// First, try legacy directory.
+		size_t basesize = strlen(home) + 1 + strlen(DEFAULTDIR) + 1;
+		base = malloc(basesize);
+		snprintf(base, basesize, "%s/" DEFAULTDIR, home);
+		if (FIL_FileExists(base) == 0)
+		{
+			// Legacy directory is not accessible. Use XDG directory.
+			free(base);
+
+#ifdef __APPLE__
+			basesize = strlen(home) + strlen("/Library/Application Support/srb2-legacy") + 1;
+			base = malloc(basesize);
+			snprintf(base, basesize, "%s/Library/Application Support/srb2-legacy", home);
+#else
+			const char *xdgdatahome = I_GetXDGDataHome(home);
+			basesize = strlen(xdgdatahome) + strlen("/srb2-legacy") + 1;
+			base = malloc(basesize);
+			snprintf(base, basesize, "%s/srb2-legacy", xdgdatahome);
+#endif
+		}
+	}
+
+	return base;
+}
+#endif
+
 /**	\brief	The isWadPathOk function
 
 	\param	path	string path to check
@@ -1824,19 +1890,17 @@ static const char *locateWad(void)
 		return returnWadPath;
 #endif
 #ifndef NOHOME
-	// find in $HOME
-	I_OutputMsg(",HOME/" DEFAULTDIR);
-	if ((envstr = I_GetEnv("HOME")) != NULL)
+#ifdef NATIVEDIR
+	// find in config dir
+	envstr = I_ConfigDir();
+	I_OutputMsg(",%s", envstr);
+	if (envstr != NULL)
 	{
-		char *tmp = malloc(strlen(envstr) + 1 + sizeof(DEFAULTDIR));
-		strcpy(tmp, envstr);
-		strcat(tmp, "/");
-		strcat(tmp, DEFAULTDIR);
-		WadPath = searchWad(tmp);
-		free(tmp);
+		WadPath = searchWad(envstr);
 		if (WadPath)
 			return WadPath;
 	}
+#endif
 #endif
 #ifdef DEFAULTSEARCHPATH1
 	// find in /usr/local

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -1677,6 +1677,7 @@ static const char *I_GetXDGDataDirs(void)
 		return "/usr/local/share/:/usr/share/";
 	return datadirs;
 }
+#endif
 
 //
 // I_ConfigDir
@@ -1684,6 +1685,7 @@ static const char *I_GetXDGDataDirs(void)
 //
 const char *I_ConfigDir()
 {
+#ifdef NATIVEDIR
 	static char *base = NULL;
 
 	if (!base)
@@ -1713,8 +1715,10 @@ const char *I_ConfigDir()
 	}
 
 	return base;
-}
+#else
+	return NULL;
 #endif
+}
 
 /**	\brief	The isWadPathOk function
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -310,7 +310,13 @@ enum {
 	LE_BRAKVILEATACK   = -6  // Brak's doing his LOS attack, oh noes
 };
 
-// Name of local directory for config files and savegames
+// Use XDG Base Directory Specification (*nix) or Application Support (macOS) by default if defined
+#if (defined (__unix__) || defined (UNIXCOMMON)) && !defined(__ANDROID__)
+#define NATIVEDIR
+#endif
+
+// Name of fallback local directory for config files and savegames
+// Depreciated in favor of NATIVEDIR
 #if (defined (__unix__) || defined (UNIXCOMMON)) && !defined (__CYGWIN__) && !defined (__APPLE__)
 #define DEFAULTDIR ".srb2_21"
 #else

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -268,17 +268,9 @@ char *I_GetUserName(void);
 */
 INT32 I_mkdir(const char *dirname, INT32 unixright);
 
-#ifdef NATIVEDIR
 /**	\brief Returns the path for SRB2's home folder
 */
 const char *I_ConfigDir();
-
-#ifndef __APPLE__
-/**	\brief Get XDG_DATA_HOME
-*/
-const char *I_GetXDGDataHome(const char *userhome);
-#endif
-#endif
 
 /**	\brief Find main WAD
 		\return path to main WAD

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -268,6 +268,18 @@ char *I_GetUserName(void);
 */
 INT32 I_mkdir(const char *dirname, INT32 unixright);
 
+#ifdef NATIVEDIR
+/**	\brief Returns the path for SRB2's home folder
+*/
+const char *I_ConfigDir();
+
+#ifndef __APPLE__
+/**	\brief Get XDG_DATA_HOME
+*/
+const char *I_GetXDGDataHome(const char *userhome);
+#endif
+#endif
+
 /**	\brief Find main WAD
 		\return path to main WAD
 */

--- a/src/sdl/SDL_main/SDL_android_main.c
+++ b/src/sdl/SDL_main/SDL_android_main.c
@@ -62,7 +62,7 @@ static void ShowSplashScreen(void)
 #define REQUEST_STORAGE_PERMISSION
 
 #define REQUEST_MESSAGE_TITLE "Permission required"
-#define REQUEST_MESSAGE_TEXT "Sonic Robo Blast 2 Legacy needs storage permission.\nYour settings and game progress will not be saved if you decline."
+#define REQUEST_MESSAGE_TEXT "SRB2 Legacy needs storage permission.\nYour settings and game progress will not be saved if you decline."
 
 static void PermissionRequestMessage(void)
 {
@@ -156,13 +156,6 @@ void I_InitLogging(void)
 					"%s"PATHSEP "%s"PATHSEP, logdir, reldir);
 		}
 		else
-#elif defined(DEFAULTDIR)
-		if (logdir)
-		{
-			left = snprintf(logfilename, sizeof logfilename,
-					"%s"PATHSEP DEFAULTDIR PATHSEP"%s"PATHSEP, logdir, reldir);
-		}
-		else
 #endif
 		{
 			left = snprintf(logfilename, sizeof logfilename,
@@ -179,12 +172,7 @@ void I_InitLogging(void)
 
 #ifdef LOGSYMLINK
 	logstream = fopen(logfilename, "w");
-#ifdef DEFAULTDIR
-	if (logdir)
-		link = va("%s/"DEFAULTDIR"/latest-log.txt", logdir);
-	else
-#endif/*DEFAULTDIR*/
-		link = "latest-log.txt";
+	link = "latest-log.txt";
 	unlink(link);
 	if (symlink(logfilename, link) == -1)
 	{
@@ -230,7 +218,7 @@ int main(int argc, char* argv[])
 		I_InitLogging();
 #endif
 
-	CONS_Printf("Sonic Robo Blast 2 Legacy for Android\n");
+	CONS_Printf("SRB2 Legacy for Android\n");
 
 #ifdef LOGMESSAGES
 	if (logstream)
@@ -243,7 +231,7 @@ int main(int argc, char* argv[])
 #endif
 
 	// Begin the normal game setup and loop.
-	CONS_Printf("Setting up Sonic Robo Blast 2 Legacy...\n");
+	CONS_Printf("Setting up SRB2 Legacy...\n");
 	D_SRB2Main();
 
 	CONS_Printf("Entering main game loop...\n");

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -74,7 +74,9 @@ typedef BOOL (WINAPI *p_IsDebuggerPresent)(VOID);
 static void InitLogging(void)
 {
 	const char *homedir = NULL;
+#ifdef NATIVEDIR
 	const char *logdir = NULL;
+#endif
 	time_t my_time;
 	struct tm * timeinfo;
 	const char *format;
@@ -86,8 +88,6 @@ static void InitLogging(void)
 #endif
 
 	homedir = D_Home();
-	if (homedir)
-		logdir = I_ConfigDir();
 
 	my_time = time(NULL);
 	timeinfo = localtime(&my_time);
@@ -123,6 +123,7 @@ static void InitLogging(void)
 #ifdef NATIVEDIR
 		if (homedir)
 		{
+			logdir = I_ConfigDir();
 			left = snprintf(logfilename, sizeof logfilename,
 					"%s"PATHSEP"%s"PATHSEP, logdir, reldir);
 		}
@@ -138,7 +139,7 @@ static void InitLogging(void)
 	}
 
 	M_MkdirEachUntil(logfilename,
-			M_PathParts(logdir) - 1,
+			M_PathParts(homedir) - 1,
 			M_PathParts(logfilename) - 1, 0755);
 
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)

--- a/src/sdl/i_main.c
+++ b/src/sdl/i_main.c
@@ -73,6 +73,7 @@ typedef BOOL (WINAPI *p_IsDebuggerPresent)(VOID);
 #ifdef LOGMESSAGES
 static void InitLogging(void)
 {
+	const char *homedir = NULL;
 	const char *logdir = NULL;
 	time_t my_time;
 	struct tm * timeinfo;
@@ -84,7 +85,9 @@ static void InitLogging(void)
 	const char *link;
 #endif
 
-	logdir = D_Home();
+	homedir = D_Home();
+	if (homedir)
+		logdir = I_ConfigDir();
 
 	my_time = time(NULL);
 	timeinfo = localtime(&my_time);
@@ -117,14 +120,14 @@ static void InitLogging(void)
 					"%s"PATHSEP, reldir);
 		}
 		else
-#ifdef DEFAULTDIR
-		if (logdir)
+#ifdef NATIVEDIR
+		if (homedir)
 		{
 			left = snprintf(logfilename, sizeof logfilename,
-					"%s"PATHSEP DEFAULTDIR PATHSEP"%s"PATHSEP, logdir, reldir);
+					"%s"PATHSEP"%s"PATHSEP, logdir, reldir);
 		}
 		else
-#endif/*DEFAULTDIR*/
+#endif/*NATIVEDIR*/
 		{
 			left = snprintf(logfilename, sizeof logfilename,
 					"."PATHSEP"%s"PATHSEP, reldir);
@@ -140,11 +143,11 @@ static void InitLogging(void)
 
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
 	logstream = fopen(logfilename, "w");
-#ifdef DEFAULTDIR
-	if (logdir)
-		link = va("%s/"DEFAULTDIR"/latest-log.txt", logdir);
+#ifdef NATIVEDIR
+	if (homedir)
+		link = va("%s/latest-log.txt", logdir);
 	else
-#endif/*DEFAULTDIR*/
+#endif/*NATIVEDIR*/
 		link = "latest-log.txt";
 	unlink(link);
 	if (symlink(logfilename, link) == -1)

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2970,6 +2970,7 @@ static const char *I_GetXDGDataDirs(void)
 		return "/usr/local/share/:/usr/share/";
 	return datadirs;
 }
+#endif
 
 //
 // I_ConfigDir
@@ -2977,6 +2978,7 @@ static const char *I_GetXDGDataDirs(void)
 //
 const char *I_ConfigDir()
 {
+#ifdef NATIVEDIR
 	static char *base = NULL;
 
 	if (!base)
@@ -3009,8 +3011,10 @@ const char *I_ConfigDir()
 	}
 
 	return base;
-}
+#else
+	return NULL;
 #endif
+}
 
 /**	\brief	The isWadPathOk function
 

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2950,6 +2950,75 @@ const char *I_ClipboardPaste(void)
 	return (const char *)&clipboard_modified;
 }
 
+#ifdef NATIVEDIR
+#ifndef __APPLE__
+// Reference for XDG directories:
+// <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+// from dsda-doom
+const char *I_GetXDGDataHome(const char *userhome)
+{
+	static char *datahome = 0;
+
+	if (!datahome)
+	{
+		const char *xdgdatahome = I_GetEnv("XDG_DATA_HOME");
+
+		if (!xdgdatahome || !*xdgdatahome)
+		{
+			size_t datahomesize = strlen(userhome) + strlen("/.local/share") + 1;
+			datahome = malloc(datahomesize);
+			snprintf(datahome, datahomesize, "%s%s%s", userhome, userhome[strlen(userhome)-1] != '/' ? "/" : "", ".local/share");
+		}
+		else
+		{
+			datahome = strdup(xdgdatahome);
+		}
+	}
+	return datahome;
+}
+#endif
+
+//
+// I_ConfigDir
+// from dsda-doom
+//
+const char *I_ConfigDir()
+{
+	static char *base = NULL;
+
+	if (!base)
+	{
+		const char *home = D_Home();
+
+		// First, try legacy directory.
+		size_t basesize = strlen(home) + 1 + strlen(DEFAULTDIR) + 1;
+		base = malloc(basesize);
+		snprintf(base, basesize, "%s/" DEFAULTDIR, home);
+
+#ifndef __EMSCRIPTEN__
+		if (FIL_FileExists(base) == 0)
+		{
+			// Legacy directory is not accessible. Use XDG directory.
+			free(base);
+
+#ifdef __APPLE__
+			basesize = strlen(home) + strlen("/Library/Application Support/srb2-legacy") + 1;
+			base = malloc(basesize);
+			snprintf(base, basesize, "%s/Library/Application Support/srb2-legacy", home);
+#else
+			const char *xdgdatahome = I_GetXDGDataHome(home);
+			basesize = strlen(xdgdatahome) + strlen("/srb2-legacy") + 1;
+			base = malloc(basesize);
+			snprintf(base, basesize, "%s/srb2-legacy", xdgdatahome);
+#endif
+		}
+#endif
+	}
+
+	return base;
+}
+#endif
+
 /**	\brief	The isWadPathOk function
 
 	\param	path	string path to check
@@ -3153,19 +3222,17 @@ static const char *locateWad(void)
 		return returnWadPath;
 #endif
 #ifndef NOHOME
-	// find in $HOME
-	I_OutputMsg(",HOME/" DEFAULTDIR);
-	if ((envstr = I_GetEnv("HOME")) != NULL)
+#ifdef NATIVEDIR
+	// find in config dir
+	envstr = I_ConfigDir();
+	I_OutputMsg(",%s", envstr);
+	if (envstr != NULL)
 	{
-		char *tmp = malloc(strlen(envstr) + 1 + sizeof(DEFAULTDIR));
-		strcpy(tmp, envstr);
-		strcat(tmp, "/");
-		strcat(tmp, DEFAULTDIR);
-		WadPath = searchWad(tmp);
-		free(tmp);
+		WadPath = searchWad(envstr);
 		if (WadPath)
 			return WadPath;
 	}
+#endif
 #endif
 #ifdef DEFAULTSEARCHPATH1
 	// find in /usr/local

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -3051,6 +3051,7 @@ static boolean isWadPathOk(const char *path)
 	return false;
 }
 
+#ifdef NATIVEDIR
 static void pathonly(char *s)
 {
 	size_t j;
@@ -3094,6 +3095,7 @@ static const char *searchWad(const char *searchDir)
 	}
 	return NULL;
 }
+#endif
 
 /**	\brief go through all possible paths and look for srb2.srb
 
@@ -3102,7 +3104,10 @@ static const char *searchWad(const char *searchDir)
 static const char *locateWad(void)
 {
 	const char *envstr;
+#if defined(NATIVEDIR) || defined(__ANDROID__)
 	const char *WadPath;
+#endif
+
 #if defined(__ANDROID__)
 	// Access the shared storage location
 	WadPath = I_SharedStorageLocation();

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -161,22 +161,6 @@ typedef LPVOID (WINAPI *p_MapViewOfFile) (HANDLE, DWORD, DWORD, DWORD, SIZE_T);
 #define UNIXBACKTRACE
 #endif
 
-// Locations for searching the srb2.srb
-#if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
-#define DEFAULTWADLOCATION1 "/usr/local/share/games/SRB2legacy"
-#define DEFAULTWADLOCATION2 "/usr/local/games/SRB2legacy"
-#define DEFAULTWADLOCATION3 "/usr/share/games/SRB2legacy"
-#define DEFAULTWADLOCATION4 "/usr/games/SRB2legacy"
-#define DEFAULTSEARCHPATH1 "/usr/local/games"
-#define DEFAULTSEARCHPATH2 "/usr/games"
-#define DEFAULTSEARCHPATH3 "/usr/local"
-#elif defined (_WIN32)
-#define DEFAULTWADLOCATION1 "c:\\games\\srb2legacy"
-#define DEFAULTWADLOCATION2 "\\games\\srb2legacy"
-#define DEFAULTSEARCHPATH1 "c:\\games"
-#define DEFAULTSEARCHPATH2 "\\games"
-#endif
-
 /**	\brief WAD file to look for
 */
 #define WADKEYWORD1 "srb2.srb"
@@ -2978,6 +2962,15 @@ const char *I_GetXDGDataHome(const char *userhome)
 }
 #endif
 
+static const char *I_GetXDGDataDirs(void)
+{
+	const char *datadirs = I_GetEnv("XDG_DATA_DIRS");
+
+	if (!datadirs || !*datadirs)
+		return "/usr/local/share/:/usr/share/";
+	return datadirs;
+}
+
 //
 // I_ConfigDir
 // from dsda-doom
@@ -3174,55 +3167,45 @@ static const char *locateWad(void)
 		return returnWadPath;
 	}
 #endif
-#ifdef ANDROID
+#ifdef __ANDROID__
 	return "/storage/emulated/0/SRB2 Legacy";
 #endif
 
-	// examine default dirs
-#ifdef DEFAULTWADLOCATION1
-	I_OutputMsg(","DEFAULTWADLOCATION1);
-	strcpy(returnWadPath, DEFAULTWADLOCATION1);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION2
-	I_OutputMsg(","DEFAULTWADLOCATION2);
-	strcpy(returnWadPath, DEFAULTWADLOCATION2);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION3
-	I_OutputMsg(","DEFAULTWADLOCATION3);
-	strcpy(returnWadPath, DEFAULTWADLOCATION3);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION4
-	I_OutputMsg(","DEFAULTWADLOCATION4);
-	strcpy(returnWadPath, DEFAULTWADLOCATION4);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION5
-	I_OutputMsg(","DEFAULTWADLOCATION5);
-	strcpy(returnWadPath, DEFAULTWADLOCATION5);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION6
-	I_OutputMsg(","DEFAULTWADLOCATION6);
-	strcpy(returnWadPath, DEFAULTWADLOCATION6);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifdef DEFAULTWADLOCATION7
-	I_OutputMsg(","DEFAULTWADLOCATION7);
-	strcpy(returnWadPath, DEFAULTWADLOCATION7);
-	if (isWadPathOk(returnWadPath))
-		return returnWadPath;
-#endif
-#ifndef NOHOME
 #ifdef NATIVEDIR
+	// examine $XDG_DATA_DIRS/games/srb2-legacy and $XDG_DATA_DIRS/srb2-legacy
+	// by default this includes:
+	// - /usr/local/share/games/srb2-legacy
+	// - /usr/share/games/srb2-legacy
+	// - /usr/local/share/srb2-legacy
+	// - /usr/share/srb2-legacy
+	char *ptr, *slash, *datadirs = strdup(I_GetXDGDataDirs());
+
+	ptr = strtok(datadirs, ":");
+	while (ptr)
+	{
+		slash = ptr[strlen(ptr)-1] != '/' ? "/" : "";
+
+		I_OutputMsg(",%s%sgames/srb2-legacy", ptr, slash);
+		snprintf(returnWadPath, sizeof(returnWadPath), "%s%sgames/srb2-legacy", ptr, slash);
+		if (isWadPathOk(returnWadPath))
+		{
+			free(datadirs);
+			return returnWadPath;
+		}
+
+		I_OutputMsg(",%s%ssrb2-legacy", ptr, slash);
+		snprintf(returnWadPath, sizeof(returnWadPath), "%s%ssrb2-legacy", ptr, slash);
+		if (isWadPathOk(returnWadPath))
+		{
+			free(datadirs);
+			return returnWadPath;
+		}
+
+		ptr = strtok(NULL, ":");
+	}
+	free(datadirs);
+
+#ifndef NOHOME
 	// find in config dir
 	envstr = I_ConfigDir();
 	I_OutputMsg(",%s", envstr);
@@ -3234,27 +3217,7 @@ static const char *locateWad(void)
 	}
 #endif
 #endif
-#ifdef DEFAULTSEARCHPATH1
-	// find in /usr/local
-	I_OutputMsg(", in:"DEFAULTSEARCHPATH1);
-	WadPath = searchWad(DEFAULTSEARCHPATH1);
-	if (WadPath)
-		return WadPath;
-#endif
-#ifdef DEFAULTSEARCHPATH2
-	// find in /usr/games
-	I_OutputMsg(", in:"DEFAULTSEARCHPATH2);
-	WadPath = searchWad(DEFAULTSEARCHPATH2);
-	if (WadPath)
-		return WadPath;
-#endif
-#ifdef DEFAULTSEARCHPATH3
-	// find in ???
-	I_OutputMsg(", in:"DEFAULTSEARCHPATH3);
-	WadPath = searchWad(DEFAULTSEARCHPATH3);
-	if (WadPath)
-		return WadPath;
-#endif
+
 	// if nothing was found
 	return NULL;
 }

--- a/src/sdl/ogl_sdl.c
+++ b/src/sdl/ogl_sdl.c
@@ -102,19 +102,22 @@ boolean OglSdlSurface(INT32 w, INT32 h)
 	INT32 cbpp = cv_scr_depth.value < 16 ? 16 : cv_scr_depth.value;
 	static int majorGL = 0, minorGL = 0;
 	static boolean first_init = false;
+#ifdef NATIVEDIR
 	const char *homedir = NULL;
 	const char *gllogdir = NULL;
+#endif
 
 	if (!gllogstream)
 	{
-		homedir = D_Home();
-		if (homedir)
-			gllogdir = I_ConfigDir();
-
 #ifdef DEBUG_TO_FILE
 #ifdef NATIVEDIR
+		homedir = D_Home();
+
 		if (homedir)
+		{
+			gllogdir = I_ConfigDir();
 			gllogstream = fopen(va("%s/ogllog.txt",gllogdir), "wt");
+		}
 		else
 #endif
 			gllogstream = fopen("./ogllog.txt", "wt");

--- a/src/sdl/ogl_sdl.c
+++ b/src/sdl/ogl_sdl.c
@@ -102,17 +102,19 @@ boolean OglSdlSurface(INT32 w, INT32 h)
 	INT32 cbpp = cv_scr_depth.value < 16 ? 16 : cv_scr_depth.value;
 	static int majorGL = 0, minorGL = 0;
 	static boolean first_init = false;
+	const char *homedir = NULL;
 	const char *gllogdir = NULL;
-
 
 	if (!gllogstream)
 	{
-		gllogdir = D_Home();
+		homedir = D_Home();
+		if (homedir)
+			gllogdir = I_ConfigDir();
 
 #ifdef DEBUG_TO_FILE
-#ifdef DEFAULTDIR
-		if (gllogdir)
-				gllogstream = fopen(va("%s/"DEFAULTDIR"/ogllog.txt",gllogdir), "wt");
+#ifdef NATIVEDIR
+		if (homedir)
+			gllogstream = fopen(va("%s/ogllog.txt",gllogdir), "wt");
 		else
 #endif
 			gllogstream = fopen("./ogllog.txt", "wt");


### PR DESCRIPTION
- By default, `$XDG_DATA_HOME` is the default directory for SRB2's home folder on *nix (except macOS)
     - This is `~/.local/share/srb2-legacy` if not explicitly set
     - On macOS, this is `~/Library/Application Support/srb2-legacy`
     - If `~/.srb2_21` or `~/srb2_21` still exists, it will use that folder
- The WAD directory is now found by searching `$XDG_DATA_DIRS/games/srb2-legacy` and `$XDG_DATA_DIRS/srb2-legacy`
     - by default this includes:
          - `/usr/local/share/games/srb2-legacy`
          - `/usr/share/games/srb2-legacy`
          - `/usr/local/share/srb2-legacy`
          - `/usr/share/srb2-legacy`

Fun fact, the original `~/.srb2_21` and `~/srb2_21` directory paths were chosen for SRB2 Legacy to be backwards-compatible with a macOS build Lach made in January 2021!
<img width="380" height="300" alt="Screenshot from 2026-06-16 20-02-40" src="https://github.com/user-attachments/assets/a22b8272-acdf-4629-8230-79c6bbf019f9" />
 